### PR TITLE
Make install docs a little more user-friendly for new rustaceans

### DIFF
--- a/src/getting-started/installing-rust.md
+++ b/src/getting-started/installing-rust.md
@@ -123,8 +123,7 @@ esp
 To view the installed `Xtensa` targets:
 
 ```bash
-$ rustup default esp
-$ rustc --print target-list | grep xtensa
+$ rustup run esp rustc --print target-list | grep xtensa
 xtensa-esp32-espidf
 xtensa-esp32-none-elf
 xtensa-esp32s2-espidf

--- a/src/getting-started/installing-rust.md
+++ b/src/getting-started/installing-rust.md
@@ -123,7 +123,7 @@ esp
 To view the installed `Xtensa` targets:
 
 ```bash
-$ rustup run esp rustc --print target-list | grep xtensa
+$ rustc +esp --print target-list | grep xtensa
 xtensa-esp32-espidf
 xtensa-esp32-none-elf
 xtensa-esp32s2-espidf


### PR DESCRIPTION
Make install docs a little more user-friendly for new rustaceans by not telling them to set rustup target.

I could see someone who is new to rustup not realizing they set their toolchain to `esp` then being confused later on when, for example, their rust version doesn't update.
