### PR TITLE
Fix PowerShell command

### DIFF
--- a/src/getting-started/installing-rust.md
+++ b/src/getting-started/installing-rust.md
@@ -74,7 +74,7 @@ With GUI installer: [https://github.com/espressif/idf-installer/releases]
 With PowerShell:
 
 ```powershell
-PS> Invoke-WebRequest https://raw.githubusercontent.com/esp-rs/rust-build/main/Install-RustToolchain.ps1
+PS> Invoke-WebRequest https://raw.githubusercontent.com/esp-rs/rust-build/main/Install-RustToolchain.ps1 -OutFile Install-RustToolchain.ps1
 PS> ./Install-RustToolchain.ps1
 ```
 


### PR DESCRIPTION
Since I'm currently trying to force myself to use Windows 11 I was following the steps on a new system and found out the PowerShell command to download the `Install-RustToolchain.ps1` script seems to not work for me (PowerShell 7) - this fixes the command