### PR TITLE
debugging software for esp chips

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -8,6 +8,9 @@
   - [Text Editors and IDEs](./tooling/text-editors-and-ides.md)
   - [espflash](./tooling/espflash.md)
   - [espmonitor](./tooling/espmonitor.md)
+  - [Debugging](./tooling/debugging/index.md)
+    - [probe-rs](./tooling/debugging/probe-rs.md)
+    - [OpenOCD](./tooling/debugging/openocd.md)
 
 ---
 

--- a/src/tooling/debugging/index.md
+++ b/src/tooling/debugging/index.md
@@ -1,0 +1,1 @@
+# Debugging

--- a/src/tooling/debugging/openocd.md
+++ b/src/tooling/debugging/openocd.md
@@ -1,0 +1,22 @@
+
+# OpenOCD
+
+Similar to [probe-rs](./probe-rs.md), OpenOCD does not have support for the Xtensa architecture. However, Espressif does maintain a fork of OpenOCD under [espressif/openocd-esp32](https://github.com/espressif/openocd-esp32) which has support for Espressif's chips.
+
+Instructions on how to install `openocd-esp32` for your platform can be found in [the Espressif documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/jtag-debugging/index.html#setup-of-openocd).
+
+## Setup for Espressif chips
+
+<!-- how to choose interface & chip -->
+
+Once installed, it's as simple as running `openocd` with the correct scripts. For chips with the builtin USB JTAG, there is normally a config that will work out of the box, for example on the ESP32-C3:
+
+```ignore
+openocd -f board/esp32c3-builtin.cfg
+```
+
+For other configurations it may require specifying the chip and the interface separately, for example ESP32 with a J-Link:
+
+```ignore
+openocd -f interface/jlink.cfg -f target/esp32.cfg
+```

--- a/src/tooling/debugging/probe-rs.md
+++ b/src/tooling/debugging/probe-rs.md
@@ -1,0 +1,31 @@
+# probe-rs
+
+The probe-rs project is a set of tools to interact with embedded MCU's using various debug probes. It is similar to openOCD, PyOCD, Segger tools etc. There is support for ARM & RISCV architectures along with a collection of tools, including but not limited to:
+
+- Debugger
+  - GDB support.
+  - CLI for interactive debugging.
+  - VSCode extension.
+- RTT (Real Time Transfer)
+  - Similar to app_trace component of IDF.
+- Flashing algorithms
+
+More info about probe-rs & how to set up a project, can be found on the [probe.rs](https://probe.rs/) website.
+
+## `USB-JTAG-SERIAL` peripheral for ESP32-C3 
+
+Starting from `probe-rs` v0.12, it is possible to flash and debug the ESP32-C3 with the builtin `USB-JTAG-SERIAL` peripheral, no need for any external hardware debugger. More info on configuring the interface can be found in the [official documentation].
+
+## Support for Espressif chips
+
+`probe-rs` currently only supports ARM & RISCV, therefore this limits the number of Espressif chips that can be used at the moment.
+
+|   Chip   |   Flashing   |   Debugging   |
+| :------: | :----------: | :-----------: |
+| ESP32-C3 |      ✅      |       ⚠️      |
+
+**Note**: _items marked with ⚠️ are currently work in progress, usable but expect bugs._
+
+[official documentation]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/jtag-debugging/configure-builtin-jtag.html
+
+<!-- TODO: when probe-rs can actually debug at least a C3 with decent back traces etc, add a section here with an example config: see https://github.com/probe-rs/probe-rs/issues/877 -->


### PR DESCRIPTION
* Adds some brief notes about the two most popular options for debugging
Rust applications with Espressif chips. Mostly based around the C3, as
probe-rs does not yet support any Xtensa chips.