### PR TITLE
Add the git repository icon to the top menu

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,3 +6,6 @@ language = "en"
 
 [rust]
 edition = "2018"
+
+[output.html]
+git-repository-url = "https://github.com/esp-rs/book"


### PR DESCRIPTION
Add the missing icon in the same way it is used in the Rust Book.