### PR TITLE
debug: add section about udev rules for probe access on linux

### DIFF
--- a/src/tooling/debugging/probe-rs.md
+++ b/src/tooling/debugging/probe-rs.md
@@ -28,4 +28,19 @@ Starting from `probe-rs` v0.12, it is possible to flash and debug the ESP32-C3 w
 
 [official documentation]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/jtag-debugging/configure-builtin-jtag.html
 
+## Permissions - Linux
+
+On linux you may run into permission issues trying to interact with Espressif probes. Installing the following `udev` rules and reloading should fix that issue.
+
+```udev
+# Espressif dev kit FTDI
+ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", MODE="660", GROUP="plugdev", TAG+="uaccess"
+
+# Espressif USB JTAG/serial debug unit
+ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1001", MODE="660", GROUP="plugdev", TAG+="uaccess"
+
+# Espressif USB Bridge
+ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1002", MODE="660", GROUP="plugdev", TAG+="uaccess"
+```
+
 <!-- TODO: when probe-rs can actually debug at least a C3 with decent back traces etc, add a section here with an example config: see https://github.com/probe-rs/probe-rs/issues/877 -->


### PR DESCRIPTION
Whilst testing some probe-rs PR's I ran into some permission issues. This didn't use to be an issue, but lets document this just in case someone else runs into it.