### PR TITLE
Use default branch when cloning rust compiler

### DIFF
--- a/src/dependencies/installing-rust.md
+++ b/src/dependencies/installing-rust.md
@@ -122,7 +122,7 @@ You can also build the Rust compiler with `Xtensa` support from source. This pro
 To check out the repository and build the compiler:
 
 ```bash
-$ git clone -b esp https://github.com/esp-rs/rust
+$ git clone https://github.com/esp-rs/rust
 $ cd rust
 $ ./configure --experimental-targets=Xtensa
 $ ./x.py build --stage 2


### PR DESCRIPTION
While following the Rust Book for ESP, I chose to take the build option for the compiler. I have been struggling to build a basic ESP example (based from [the suggested template](https://esp-rs.github.io/book/writing-your-application/generate-project-from-template.html)), encountering build errors like the following : 
```
error: unknown `--json` option `future-incompat`
```
Googling a bit, it appears that error could be linked to a too old rustc compiler. I changed the branch suggested in current documentation by the most recent branch on https://github.com/esp-rs/rust, which appears to be `esp-1.61.0.0`. Building this branch and trying to generate and build the basic template makes the error disappear.
The `esp` branch seems to be quite far behind the `esp-1.61.0.0` branch, which is, moreover, the default branch. So I guess there is no point to force the `esp` branch when cloning the rustc compiler ?