### PR TITLE
Recommend Set-ExecutionPolicy Bypass before executing PowerShell scripts

### DIFF
--- a/src/dependencies/installing-rust.md
+++ b/src/dependencies/installing-rust.md
@@ -100,6 +100,7 @@ With PowerShell:
 
 ```powershell
 PS> Invoke-WebRequest https://raw.githubusercontent.com/esp-rs/rust-build/main/Install-RustToolchain.ps1 -OutFile Install-RustToolchain.ps1
+PS> Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
 PS> ./Install-RustToolchain.ps1
 ```
 


### PR DESCRIPTION
The default Execution Policy for Windows systems forbids execution of scripts regardless of their origin (see https://go.microsoft.com/fwlink/?LinkID=135170).
As such, we must change this, at least for the current PowerShell process. Using `-Scope Process` ensures that we don't make any persistent change.