### PR TITLE
Update information regarding esp-hal and esp-wifi, mention esp-backtrace

### DIFF
--- a/src/overview/bare-metal.md
+++ b/src/overview/bare-metal.md
@@ -9,14 +9,14 @@ It's important to note that in general a `no_std` crate can always compile in `s
 
 ## Hardware Abstraction Layers
 
-Previously, the primary focus of `no_std` development was the ESP32 and (to a lesser extent) the ESP8266, via [esp-rs/esp32-hal] and [esp-rs/esp8266-hal].
+Previously, the primary focus of `no_std` development was the ESP32 and (to a lesser extent) the ESP8266.
 
-While `esp32-hal` and `esp8266-hal` have great support for a lot of the onboard peripherals, Wi-Fi and Bluetooth are **not** currently supported in a `no_std` enviroment. [esp-rs/esp32-wifi] was created to explore getting it working, but it is not yet functional.
+Now there is a renewed effort to implement `no_std` support for the entire lineup of Espressif devices from the ESP32 and newer. These new HALs can be found in the [esp-rs/esp-hal] repository.
 
-More recently, there has been a renewed effort to implement `no_std` support for the entire lineup of Espressif devices from the ESP32 and newer. These new HALs can be found in the [esp-rs/esp-hal] repository.
+There is also some level of support for Wi-Fi and Bluetooth via [esp-rs/esp-wifi] for ESP32 and ESP32-C3.
 
-[esp-rs/esp32-hal]: https://github.com/esp-rs/esp32-hal
-[esp-rs/esp32-wifi]: https://github.com/esp-rs/esp32-wifi
+[esp-rs/esp-hal]: https://github.com/esp-rs/esp-hal
+[esp-rs/esp-wifi]: https://github.com/esp-rs/esp-wifi
 
 ## Chip Support
 

--- a/src/overview/comparing-std-and-no_std.md
+++ b/src/overview/comparing-std-and-no_std.md
@@ -1,14 +1,14 @@
 # Comparing `std` and `no_std`
 
-There are a number of factors which must be considered when choosing between `std` ([esp-idf-hal]) and `no_std` (eg. [esp32-hal]). As stated previously, each approach has its own unique set of advantages and disadvantages. While we can't decide for you, this section will hopefully allow you to make an educated decision.
+There are a number of factors which must be considered when choosing between `std` ([esp-idf-hal]) and `no_std` (eg. [esp-hal]). As stated previously, each approach has its own unique set of advantages and disadvantages. While we can't decide for you, this section will hopefully allow you to make an educated decision.
 
 At present, there are unfortunately certain technical restrictions which may dictate your choice; we hope to have these issues resolved soon. Currently you _must_ use the `std` approach if you require any of the following:
 
-- Use of Wi-Fi or Bluetooth
-- The ability to target any chip other than the ESP32 or the ESP8266
+- Use of Wi-Fi or Bluetooth on a chip other than ESP32 or ESP32-C3
+- The ability to target any chip other than the ESP32, ESP32-C3, ESP32-S2, ESP32-S3 or the ESP8266
 
 [esp-idf-hal]: https://github.com/esp-rs/esp-idf-hal
-[esp32-hal]: https://github.com/esp-rs/esp32-hal
+[esp-hal]: https://github.com/esp-rs/esp-hal
 
 ## Application Runtimes
 
@@ -66,6 +66,9 @@ These can be used simply by installing the relevant dependency, and then importi
 use panic_halt as _;
 ```
 
+Probably the most convenient panic handler for `no_std` on `esp-hal` is [esp-backtrace]
+
 [panic-halt]: https://github.com/korken89/panic-halt
 [panic-semihosting]: https://github.com/rust-embedded/cortex-m/tree/master/panic-semihosting
 [panic-never]: https://github.com/japaric/panic-never
+[esp-backtrace]: https://github.com/esp-rs/esp-backtrace


### PR DESCRIPTION
The old text was still talking about `esp32-hal` and `esp32-wifi`
Also mentioning `esp-backtrace` as a good panic handler