### PR TITLE
Add troubleshooting section

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -7,6 +7,7 @@
   - [Comparing `std` and `no_std`](./overview/comparing-std-and-no_std.md)
 - [Rust on ESP targets](./installation/index.md)
   - [Installation](./installation/installation.md)
+  - [Troubleshooting](./installation/troubleshooting.md)
 - [Tooling](./tooling/index.md)
   - [Text Editors and IDEs](./tooling/text-editors-and-ides.md)
   - [espflash](./tooling/espflash.md)

--- a/src/installation/troubleshooting.md
+++ b/src/installation/troubleshooting.md
@@ -75,6 +75,6 @@ For more information on toolchain overriding, see the [Overrides chapter of The 
 [for Xtensa targets, you need to use Espressif Rust fork toolchain]: index.md#rust-in-xtensa-targets
 [toolchain override]: https://rust-lang.github.io/rustup/overrides.html#toolchain-override-shorthand
 [directory override]: https://rust-lang.github.io/rustup/overrides.html#directory-overrides
-[rust-toolchain.toml]: ttps://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+[rust-toolchain.toml]: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [default toolchain]: https://rust-lang.github.io/rustup/overrides.html#default-toolchain
 [Overrides chapter of The rustup book]: https://rust-lang.github.io/rustup/overrides.html#overrides

--- a/src/installation/troubleshooting.md
+++ b/src/installation/troubleshooting.md
@@ -3,24 +3,24 @@
 Here, we will present a list of common errors that may appear when building a project alongside the reason and a solution to them.
 
 ## Environment variable LIBCLANG_PATH not set
-```
+```sh
 thread 'main' panicked at 'Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /home/esp/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.60.1/src/lib.rs:2172:31
 ```
 We need `libclang` for [`bindgen`] to generate the Rust bindings to the ESP-IDF C headers.
 Make sure the environment variable `LIBCLANG_PATH` is set and pointing to our custom fork of LLVM:
 - Unix:
-  ```
+  ```sh
   export $HOME/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/lib
   ```
 - Windows:
-  ```
+  ```powershell
   $Env:LIBCLANG_PATH="%USERPROFILE%/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/bin/libclang.dll"
   $Env:PATH+=";%USERPROFILE%/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/bin/"
   ```
 
 [`bindgen`]: https://github.com/rust-lang/rust-bindgen
 ## Missing `libtinfo.so.5`
-```
+```sh
 thread 'main' panicked at 'Unable to find libclang: "the `libclang` shared library at /home/user/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/lib/libclang.so.15.0.0 could not be o
 pened: libtinfo.so.5: cannot open shared object file: No such file or directory"', /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.60.1/src/lib.rs:2172:31
 ```
@@ -32,14 +32,14 @@ Our current version of LLVM, 15, requires `libtinfo.so.5`. This dependency will 
 
 
 ## Missing `ldproxy`
-```
+```sh
 error: linker `ldproxy` not found
   |
   = note: No such file or directory (os error 2)
 ```
 
 If you are trying to build a `std` application [`ldproxy`] must be installed.
-```
+```sh
 cargo install ldproxy
 ```
 For more information, see [ldproxy section].
@@ -49,7 +49,7 @@ For more information, see [ldproxy section].
 
 
 ## Using wrong Rust toolchain
-```
+```sh
 $ cargo build
 error: failed to run `rustc` to learn about target-specific information
 

--- a/src/installation/troubleshooting.md
+++ b/src/installation/troubleshooting.md
@@ -6,6 +6,7 @@ Here, we will cover some of the common errors that may appear, the reason and a 
 ```
 thread 'main' panicked at 'Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /home/esp/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.60.1/src/lib.rs:2172:31
 ```
+We need `libclang` for [`bindgen`] to generate the Rust bindings to the ESP-IDF C headers.
 Make sure the environment variable `LIBCLANG_PATH` is set and pointing to our custom fork of LLVM:
 - Unix:
   ```
@@ -17,6 +18,7 @@ Make sure the environment variable `LIBCLANG_PATH` is set and pointing to our cu
   $Env:PATH+=";%USERPROFILE%/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/bin/"
   ```
 
+[`bindgen`]: https://github.com/rust-lang/rust-bindgen
 ## Missing `libtinfo.so.5`
 ```
 thread 'main' panicked at 'Unable to find libclang: "the `libclang` shared library at /home/user/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/lib/libclang.so.15.0.0 could not be o
@@ -44,3 +46,34 @@ For more information, see [ldproxy section].
 
 [`ldproxy`]: https://github.com/esp-rs/embuild/tree/master/ldproxy
 [ldproxy section]: installation.md#ldproxy
+
+
+## Using wrong toolchain
+```
+$ cargo build
+error: failed to run `rustc` to learn about target-specific information
+
+Caused by:
+  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target xtensa-esp32-espidf --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
+  --- stderr
+  error: Error loading target specification: Could not find specification for target "xtensa-esp32-espidf". Run `rustc --print target-list` for a list of built-in targets
+```
+
+If you are encountering the previous error or a similar one, you are probably not ussing the proper Rust toolchain, remember that for Xtensa targets, you need to use Espressif Rust fork toolchain, there are several ways to do it:
+- A [toolchain override] shorthand used on the command-line: `cargo +esp`.
+- Set `RUSTUP_TOOLCHAIN` environment variable to `esp`.
+- Set a [directory override]: `rustup override set esp`
+- Add a [rust-toolchain.toml] file to you project:
+  ```toml
+  [toolchain]
+  channel = "esp"
+  ```
+- Set `esp` as [default toolchain].
+
+For more information on toolchain overriding, see the [Overrides chapter of The rustup book].
+
+[toolchain override]: https://rust-lang.github.io/rustup/overrides.html#toolchain-override-shorthand
+[directory override]: https://rust-lang.github.io/rustup/overrides.html#directory-overrides
+[rust-toolchain.toml]: ttps://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+[default toolchain]: https://rust-lang.github.io/rustup/overrides.html#default-toolchain
+[Overrides chapter of The rustup book]: https://rust-lang.github.io/rustup/overrides.html#overrides

--- a/src/installation/troubleshooting.md
+++ b/src/installation/troubleshooting.md
@@ -27,3 +27,20 @@ Our current version of LLVM, 15, requires `libtinfo.so.5`. This dependency will 
 - Fedora: `sudo dnf install ncurses-compat-libs`
 - openSUSE: `sudo dnf install libncurses5`
 - Arch Linux: `sudo pacman -S ncurses5-compat-libs`
+
+
+## Missing `ldproxy`
+```
+error: linker `ldproxy` not found
+  |
+  = note: No such file or directory (os error 2)
+```
+
+If you are triying to build a `std` application [`ldproxy`] must be installed.
+```
+cargo install ldproxy
+```
+For more information, see [ldproxy section].
+
+[`ldproxy`]: https://github.com/esp-rs/embuild/tree/master/ldproxy
+[ldproxy section]: installation.md#ldproxy

--- a/src/installation/troubleshooting.md
+++ b/src/installation/troubleshooting.md
@@ -16,3 +16,14 @@ Make sure the environment variable `LIBCLANG_PATH` is set and pointing to our cu
   $Env:LIBCLANG_PATH="%USERPROFILE%/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/bin/libclang.dll"
   $Env:PATH+=";%USERPROFILE%/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/bin/"
   ```
+
+## Missing `libtinfo.so.5`
+```
+thread 'main' panicked at 'Unable to find libclang: "the `libclang` shared library at /home/user/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/lib/libclang.so.15.0.0 could not be o
+pened: libtinfo.so.5: cannot open shared object file: No such file or directory"', /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.60.1/src/lib.rs:2172:31
+```
+Our current version of LLVM, 15, requires `libtinfo.so.5`. This dependency will probably be removed in our futures LLVM releases, but for the momment, please, make sure you have it installed:
+- Ubuntu/Debian: `sudo apt-get install libtinfo5`
+- Fedora: `sudo dnf install ncurses-compat-libs`
+- openSUSE: `sudo dnf install libncurses5`
+- Arch Linux: `sudo pacman -S ncurses5-compat-libs`

--- a/src/installation/troubleshooting.md
+++ b/src/installation/troubleshooting.md
@@ -2,3 +2,17 @@
 
 Here, we will cover some of the common errors that may appear, the reason and a solution to them.
 
+## Environment variable LIBCLANG_PATH not set
+```
+thread 'main' panicked at 'Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /home/esp/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.60.1/src/lib.rs:2172:31
+```
+Make sure the environment variable `LIBCLANG_PATH` is set and pointing to our custom fork of LLVM:
+- Unix:
+  ```
+  export $HOME/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/lib
+  ```
+- Windows:
+  ```
+  $Env:LIBCLANG_PATH="%USERPROFILE%/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/bin/libclang.dll"
+  $Env:PATH+=";%USERPROFILE%/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/bin/"
+  ```

--- a/src/installation/troubleshooting.md
+++ b/src/installation/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Here, we will cover some of the common errors that may appear, the reason and a solution to them.
+Here, we will present a list of common errors that may appear when building a project alongside the reason and a solution to them.
 
 ## Environment variable LIBCLANG_PATH not set
 ```
@@ -24,7 +24,7 @@ Make sure the environment variable `LIBCLANG_PATH` is set and pointing to our cu
 thread 'main' panicked at 'Unable to find libclang: "the `libclang` shared library at /home/user/.espressif/tools/xtensa-esp32-elf-clang/esp-15.0.0-20221014-x86_64-unknown-linux-gnu/esp-clang/lib/libclang.so.15.0.0 could not be o
 pened: libtinfo.so.5: cannot open shared object file: No such file or directory"', /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.60.1/src/lib.rs:2172:31
 ```
-Our current version of LLVM, 15, requires `libtinfo.so.5`. This dependency will probably be removed in our futures LLVM releases, but for the momment, please, make sure you have it installed:
+Our current version of LLVM, 15, requires `libtinfo.so.5`. This dependency will probably be removed in our future LLVM releases, but for the moment, please, make sure you have it installed:
 - Ubuntu/Debian: `sudo apt-get install libtinfo5`
 - Fedora: `sudo dnf install ncurses-compat-libs`
 - openSUSE: `sudo dnf install libncurses5`
@@ -38,7 +38,7 @@ error: linker `ldproxy` not found
   = note: No such file or directory (os error 2)
 ```
 
-If you are triying to build a `std` application [`ldproxy`] must be installed.
+If you are trying to build a `std` application [`ldproxy`] must be installed.
 ```
 cargo install ldproxy
 ```
@@ -48,7 +48,7 @@ For more information, see [ldproxy section].
 [ldproxy section]: installation.md#ldproxy
 
 
-## Using wrong toolchain
+## Using wrong Rust toolchain
 ```
 $ cargo build
 error: failed to run `rustc` to learn about target-specific information
@@ -59,7 +59,7 @@ Caused by:
   error: Error loading target specification: Could not find specification for target "xtensa-esp32-espidf". Run `rustc --print target-list` for a list of built-in targets
 ```
 
-If you are encountering the previous error or a similar one, you are probably not ussing the proper Rust toolchain, remember that for Xtensa targets, you need to use Espressif Rust fork toolchain, there are several ways to do it:
+If you are encountering the previous error or a similar one, you are probably not using the proper Rust toolchain, remember that [for Xtensa targets, you need to use Espressif Rust fork toolchain], there are several ways to do it:
 - A [toolchain override] shorthand used on the command-line: `cargo +esp`.
 - Set `RUSTUP_TOOLCHAIN` environment variable to `esp`.
 - Set a [directory override]: `rustup override set esp`
@@ -72,6 +72,7 @@ If you are encountering the previous error or a similar one, you are probably no
 
 For more information on toolchain overriding, see the [Overrides chapter of The rustup book].
 
+[for Xtensa targets, you need to use Espressif Rust fork toolchain]: index.md#rust-in-xtensa-targets
 [toolchain override]: https://rust-lang.github.io/rustup/overrides.html#toolchain-override-shorthand
 [directory override]: https://rust-lang.github.io/rustup/overrides.html#directory-overrides
 [rust-toolchain.toml]: ttps://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

--- a/src/installation/troubleshooting.md
+++ b/src/installation/troubleshooting.md
@@ -1,0 +1,4 @@
+# Troubleshooting
+
+Here, we will cover some of the common errors that may appear, the reason and a solution to them.
+


### PR DESCRIPTION
Since in `rust-build`, `espup`, `ivmarkov/rust-esp32-std-demo`, and in the templates repo we usually get some repetitive issues, I thought we could add a troubleshooting section with a short explanation and the fix for those. So we only need to share the link to the solution.

We could also update/create an issue template so users check this section before creating the issue.

Let me know if you want me to add any other common issue