### PR TITLE
QEMU: Fixing argument order and adding espflash save-image information

### DIFF
--- a/src/tooling/simulating/qemu.md
+++ b/src/tooling/simulating/qemu.md
@@ -21,11 +21,27 @@ We can use [`cargo-espflash`] to generate it:
 cargo espflash save-image --merge ESP32 <OUTFILE> --release
 ```
 
-> If you prefer to use [`espflash`], you can achieve the same result by building the project first and then generating image:
-> ```bash
+> If you prefer to use [`espflash`], you can achieve the same result by building the project first and then generating image. Following an excerpt from `espflash save-image --help`.
+>```
+>USAGE:
+>    espflash save-image [OPTIONS] <CHIP> <IMAGE> <FILE>
+>
+>ARGS:
+>    <CHIP>     Chip to create an image for [possible values: ESP32, ESP32-C2, ESP32-C3,
+>               ESP32-S2, ESP32-S3, ESP8266]
+>    <IMAGE>    ELF image to flash
+>    <FILE>     File name to save the generated image to
+>OPTIONS:
+>    [..]
+>    -M, --merge
+>            Boolean flag, if set, bootloader, partition table and application binaries will be
+>            merged into single binary
+>```
+> For example:
+>```bash 
 > cargo build --release
 > espflash save-image --merge ESP32 target/xtensa-esp32-espidf/release/<NAME> <OUTFILE>
-> ```
+>```
 
 [`espflash`]: https://github.com/esp-rs/espflash/tree/main/espflash
 

--- a/src/tooling/simulating/qemu.md
+++ b/src/tooling/simulating/qemu.md
@@ -21,23 +21,7 @@ We can use [`cargo-espflash`] to generate it:
 cargo espflash save-image --merge ESP32 <OUTFILE> --release
 ```
 
-> If you prefer to use [`espflash`], you can achieve the same result by building the project first and then generating image. Following an excerpt from `espflash save-image --help`.
->```
->USAGE:
->    espflash save-image [OPTIONS] <CHIP> <IMAGE> <FILE>
->
->ARGS:
->    <CHIP>     Chip to create an image for [possible values: ESP32, ESP32-C2, ESP32-C3,
->               ESP32-S2, ESP32-S3, ESP8266]
->    <IMAGE>    ELF image to flash
->    <FILE>     File name to save the generated image to
->OPTIONS:
->    [..]
->    -M, --merge
->            Boolean flag, if set, bootloader, partition table and application binaries will be
->            merged into single binary
->```
-> For example:
+> If you prefer to use [`espflash`], you can achieve the same result by building the project first and then generating image:
 >```bash 
 > cargo build --release
 > espflash save-image --merge ESP32 target/xtensa-esp32-espidf/release/<NAME> <OUTFILE>

--- a/src/tooling/simulating/qemu.md
+++ b/src/tooling/simulating/qemu.md
@@ -24,7 +24,7 @@ cargo espflash save-image --merge ESP32 <OUTFILE> --release
 > If you prefer to use [`espflash`], you can achieve the same result by building the project first and then generating image:
 > ```bash
 > cargo build --release
-> espflash save-image --merge ESP32 <OUTFILE> target/xtensa-esp32-espidf/release/<NAME>
+> espflash save-image --merge ESP32 target/xtensa-esp32-espidf/release/<NAME> <OUTFILE>
 > ```
 
 [`espflash`]: https://github.com/esp-rs/espflash/tree/main/espflash


### PR DESCRIPTION
Hi,

Thank you for all the work already being done, it was really helpful!

In the QEMU section, I noticed, that the command about directly calling `espflash save-image` didn't work for me.
Switching both arguments worked.

Following the reason for both commits:
1. The first commit switches the arguments and puts OUTFILE at last.
2. The second commit adds a description about the arguments being used (taken from `espflash save-image --help` )

I hope, it might be helpful. 

With best regards
Ingolf