### PR TITLE
Fix of minor typos

### DIFF
--- a/src/overview/index.md
+++ b/src/overview/index.md
@@ -15,7 +15,8 @@ The [esp-rs organization] on GitHub is home to a number of repositories related 
 
 > A note on the repository naming convention
 > In the [esp-rs organization] we use the folling wording:
-> - Repositories starting with `esp-idf-` are focused on `std` apporach. E.g. `esp-idf-hal`
-> - Repositories starting with `esp-` are focused on `no_std` apporach. E.g. `esp-hal`
+>
+> - Repositories starting with `esp-idf-` are focused on `std` approach. E.g. `esp-idf-hal`
+> - Repositories starting with `esp-` are focused on `no_std` approach. E.g. `esp-hal`
 
 [esp-rs organization]: https://github.com/esp-rs/

--- a/src/tooling/debugging/vscode-debugging.md
+++ b/src/tooling/debugging/vscode-debugging.md
@@ -65,7 +65,7 @@ ESP32-C3 with **revision 3** **does** have a built-in JTAG interface and you don
 
 ## Hardware Setup
 
-If your ESP32-C3's revision is lesser than 3, follow these instructions, if you have revision 3 you can jump to the **Set up VSCode** step.
+If your ESP32-C3's revision is lesser than 3, follow these instructions, if you have revision 3 you can jump to the [**Set up VSCode**](#set-up-vscode-1) step.
 
 ESP32-C3 **revision 1** and **revision 2** don't have a built-in JTAG interface so you have to connect an external JTAG adapter to the ESP32-C3 board, for example, [ESP-Prog](https://docs.espressif.com/projects/espressif-esp-iot-solution/en/latest/hw-reference/ESP-Prog_guide.html) can be used.
 

--- a/src/tooling/debugging/vscode-debugging.md
+++ b/src/tooling/debugging/vscode-debugging.md
@@ -1,4 +1,3 @@
-
 # Debugging in Visual Studio Code
 
 There is also a possibility to debug with graphical output directly in Visual Studio Code.
@@ -18,7 +17,6 @@ ESP32 doesn't have a built-in JTAG interface so you have to connect an external 
 |     3V3     |    VJTAG    |
 |     GND     |     GND     |
 
-
 **Note**: On Windows `USB Serial Converter A 0403 6010 00` driver should be WinUSB.
 
 ## Set up VSCode
@@ -26,49 +24,42 @@ ESP32 doesn't have a built-in JTAG interface so you have to connect an external 
 1. Install [Cortex-Debug](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug) extension for VScode.
 2. Create the `.vscode/launch.json` file in the project tree you want to debug. [This](https://github.com/esp-rs/esp32-hal/blob/master/.vscode/launch.json) can be used as a template file.
 3. Update **executable**, **svdFile**, **serverpath** paths, and **toolchainPrefix** field.
+
 ```jsonc
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
     {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-            {
-                // more info at: https://github.com/Marus/cortex-debug/blob/master/package.json
-                "name": "Attach",
-                "type": "cortex-debug",
-                "request": "attach", // attach instead of launch, because otherwise flash write is attempted, but fails
-                "cwd": "${workspaceRoot}",
-                "executable": "target/xtensa-esp32-none-elf/debug/.....",
-                "servertype": "openocd",
-                "interface": "jtag",
-                "svdFile": "../../esp-pacs/esp32/svd/esp32.svd",
-                "toolchainPrefix": "xtensa-esp32-elf",
-                "openOCDPreConfigLaunchCommands": [
-                    "set ESP_RTOS none"
-                ],
-                "serverpath": "C:/Espressif/tools/openocd-esp32/v0.11.0-esp32-20220411/openocd-esp32/bin/openocd.exe",
-                "configFiles": [
-                    "board/esp32-wrover-kit-3.3v.cfg"
-                ],
-                "overrideAttachCommands": [
-                    "set remote hardware-watchpoint-limit 2",
-                    "mon halt",
-                    "flushregs"
-                ],
-                "overrideRestartCommands": [
-                    "mon reset halt",
-                    "flushregs",
-                    "c",
-                ]
-            },
-        ]
+      // more info at: https://github.com/Marus/cortex-debug/blob/master/package.json
+      "name": "Attach",
+      "type": "cortex-debug",
+      "request": "attach", // attach instead of launch, because otherwise flash write is attempted, but fails
+      "cwd": "${workspaceRoot}",
+      "executable": "target/xtensa-esp32-none-elf/debug/.....",
+      "servertype": "openocd",
+      "interface": "jtag",
+      "svdFile": "../../esp-pacs/esp32/svd/esp32.svd",
+      "toolchainPrefix": "xtensa-esp32-elf",
+      "openOCDPreConfigLaunchCommands": ["set ESP_RTOS none"],
+      "serverpath": "C:/Espressif/tools/openocd-esp32/v0.11.0-esp32-20220411/openocd-esp32/bin/openocd.exe",
+      "configFiles": ["board/esp32-wrover-kit-3.3v.cfg"],
+      "overrideAttachCommands": [
+        "set remote hardware-watchpoint-limit 2",
+        "mon halt",
+        "flushregs"
+      ],
+      "overrideRestartCommands": ["mon reset halt", "flushregs", "c"]
     }
+  ]
+}
 ```
 
 # ESP32-C3
 
-Older versions with **revision < 3** **doesn't** have built-in JTAG interface.
+Older versions with **revision < 3** **don't** have built-in JTAG interface.
 
 ESP32-C3 with **revision 3** **does** have a built-in JTAG interface and you don't have to connect an external device to be able to debug. To get the chip revision, run the `cargo espflash board-info` command.
 
@@ -87,7 +78,6 @@ ESP32-C3 **revision 1** and **revision 2** don't have a built-in JTAG interface 
 |     3V3      |    VJTAG    |
 |     GND      |     GND     |
 
-
 **Note**: On Windows `USB Serial Converter A 0403 6010 00` driver should be WinUSB.
 
 ## Set up VSCode
@@ -95,42 +85,35 @@ ESP32-C3 **revision 1** and **revision 2** don't have a built-in JTAG interface 
 1. Install [Cortex-Debug](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug) extension for VScode.
 2. Create the `.vscode/launch.json` file in the project tree you want to debug. [This](https://github.com/esp-rs/esp32-hal/blob/master/.vscode/launch.json) can be used as a template file.
 3. Update **executable**, **svdFile**, **serverpath** paths, and **toolchainPrefix** field.
+
 ```jsonc
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
     {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-            {
-                // more info at: https://github.com/Marus/cortex-debug/blob/master/package.json
-                "name": "Attach",
-                "type": "cortex-debug",
-                "request": "attach", // attach instead of launch, because otherwise flash write is attempted, but fails
-                "cwd": "${workspaceRoot}",
-                "executable": "target/riscv32imc-unknown-none-elf/debug/examples/usb_serial_jtag", //
-                "servertype": "openocd",
-                "interface": "jtag",
-                "svdFile": "../../esp-pacs/esp32c3/svd/esp32c3.svd",
-                "toolchainPrefix": "riscv32-esp-elf",
-                "openOCDPreConfigLaunchCommands": [
-                    "set ESP_RTOS none"
-                ],
-                "serverpath": "C:/Espressif/tools/openocd-esp32/v0.11.0-esp32-20220411/openocd-esp32/bin/openocd.exe",
-                "configFiles": [
-                    "board/esp32c3-builtin.cfg"
-                ],
-                "overrideAttachCommands": [
-                    "set remote hardware-watchpoint-limit 2",
-                    "mon halt",
-                    "flushregs"
-                ],
-                "overrideRestartCommands": [
-                    "mon reset halt",
-                    "flushregs",
-                    "c",
-                ]
-            },
-        ]
+      // more info at: https://github.com/Marus/cortex-debug/blob/master/package.json
+      "name": "Attach",
+      "type": "cortex-debug",
+      "request": "attach", // attach instead of launch, because otherwise flash write is attempted, but fails
+      "cwd": "${workspaceRoot}",
+      "executable": "target/riscv32imc-unknown-none-elf/debug/examples/usb_serial_jtag", //
+      "servertype": "openocd",
+      "interface": "jtag",
+      "svdFile": "../../esp-pacs/esp32c3/svd/esp32c3.svd",
+      "toolchainPrefix": "riscv32-esp-elf",
+      "openOCDPreConfigLaunchCommands": ["set ESP_RTOS none"],
+      "serverpath": "C:/Espressif/tools/openocd-esp32/v0.11.0-esp32-20220411/openocd-esp32/bin/openocd.exe",
+      "configFiles": ["board/esp32c3-builtin.cfg"],
+      "overrideAttachCommands": [
+        "set remote hardware-watchpoint-limit 2",
+        "mon halt",
+        "flushregs"
+      ],
+      "overrideRestartCommands": ["mon reset halt", "flushregs", "c"]
     }
+  ]
+}
 ```

--- a/src/writing-your-own-application/no-std-applications/hello-world.md
+++ b/src/writing-your-own-application/no-std-applications/hello-world.md
@@ -7,13 +7,18 @@ Traditionally the first thing to run on a microcontroller is _blinky_.
 However, we will start with _Hello World_ here.
 
 ## Add a Dependency
+
 You can add a dependency by any of the following methods:
-- Editing `Cargo.toml`
-In `Cargo.toml` in the `[dependencies]` section add this line:
+
+- By Editing `Cargo.toml`.
+  In `Cargo.toml` in the `[dependencies]` section add this line:
+
 ```toml
 esp-println = { version = "0.3.1", features = ["esp32c3"] }
 ```
+
 - Using [`cargo add`]
+
 ```sh
 cargo add esp-println --features "esp32c3"
 ```
@@ -27,6 +32,7 @@ We need to pass the feature `esp32c3` since that crate targets multiple SoCs and
 ## Print Something
 
 In `main.rs` before the `loop {}` add this line
+
 ```rust,ignore
 esp_println::println!("Hello World");
 ```
@@ -34,6 +40,7 @@ esp_println::println!("Hello World");
 ## See Results
 
 Again run
+
 ```shell
 cargo run
 ```


### PR DESCRIPTION
Read the whole book and these are the only typos I could find. Keep up the great work!

- In src/overview/index.md
  - Fixed "apporach" to "approach"
- In src/tooling/debugging/vscode-debugging.md 
  - Fixed "Older versions with **revision < 3** **doesn't** have" to "Older versions with **revision < 3** **don't** have"
  - Added link to: "jump to the [**Set up VSCode**](#set-up-vscode-1) step."
- In src/writing-your-own-application/no-std-applications/hello-world.md
  - Changed: "Editing `Cargo.toml` In `Cargo.toml`" to "By Editing `Cargo.toml`. In `Cargo.toml`". First version renders without dot and it all blends into one sentence.