### PR TITLE
Fix URLs for esp-idf-template

### DIFF
--- a/src/resources.md
+++ b/src/resources.md
@@ -10,7 +10,7 @@
 - [cargo-generate](https://github.com/cargo-generate/cargo-generate) - Tool to help you get up and running quickly with a new Rust project by leveraging a pre-existing git repository as a template.
 - [esp-hal](https://github.com/esp-rs/esp-hal) - `no_std` HAL for Espressif microcontrollers.
 - [esp-idf-hal](https://github.com/esp-rs/esp-idf-hal) - `std` HAL for Espressif microcontrollers.
-- [esp-idf-template](https://github.com/esp-rs/esp-template) - A minimal `esp-idf-hal` application template to use with `cargo-generate`.
+- [esp-idf-template](https://github.com/esp-rs/esp-idf-template) - A minimal `esp-idf-hal` application template to use with `cargo-generate`.
 - [esp-template](https://github.com/esp-rs/esp-template) - A minimal `esp-hal` application template to use with `cargo-generate`.
 - [espflash](https://github.com/esp-rs/espflash) - Serial flasher utility for Espressif SoCs and modules based on [esptool](https://github.com/espressif/esptool).
 - [espup](https://github.com/esp-rs/espup): About Tool for installing and maintaining the required toolchains for developing applications in Rust for Espressif SoC's.

--- a/src/writing-your-own-application/std-applications/understanding-esp-idf-template.md
+++ b/src/writing-your-own-application/std-applications/understanding-esp-idf-template.md
@@ -171,7 +171,7 @@ You can reboot with `CTRL+R` or exit with `CTRL+C`.
 [rust-toolchain.toml]: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [.cargo/config.toml]: https://doc.rust-lang.org/cargo/reference/config.html
 [generate a std project]: ../generate-project-from-template.md#esp-idf-template
-[esp-idf-template]: https://github.com/esp-rs/esp-template
+[esp-idf-template]: https://github.com/esp-rs/esp-idf-template
 [`esp-idf-sys`]: https://github.com/esp-rs/esp-idf-sys
 [`ldproxy`]: https://github.com/esp-rs/embuild/tree/master/ldproxy
 [build.rs]: https://doc.rust-lang.org/cargo/reference/build-scripts.html


### PR DESCRIPTION
The URLs for the **esp-idf-template** were pointing to the [esp-template](https://github.com/esp-rs/esp-template) repo (without std support).
Changed it to the [esp-idf-template](https://github.com/esp-rs/esp-idf-template) repo.