### PR TITLE
Fix `subst` path

### DIFF
--- a/src/installation/troubleshooting.md
+++ b/src/installation/troubleshooting.md
@@ -85,7 +85,7 @@ For more information on toolchain overriding, see the [Overrides chapter of The 
 
 When using Windows, you may encounter issues building a new project if using long path names. Follow these steps to substitute the path of your project:
 ```sh
-subst r:\ <pathToYourProject>
+subst r: <pathToYourProject>
 cd r:\
 ```
 


### PR DESCRIPTION
The first path written in the subst command may not contain a backslash, see here: https://learn.microsoft.com/de-de/windows-server/administration/windows-commands/subst

This PR removes the backslash which makes the command functional. Tested on Win 11.