### PR TITLE
minor espflash command update

### DIFF
--- a/src/tooling/simulating/qemu.md
+++ b/src/tooling/simulating/qemu.md
@@ -18,7 +18,7 @@ We can use [`cargo-espflash`] to generate it:
 [`cargo-espflash`]: https://github.com/esp-rs/espflash/tree/main/cargo-espflash
 
 ```bash
-cargo espflash save-image --merge ESP32 <OUTFILE> --release
+cargo espflash save-image --chip esp32 --merge <OUTFILE> --release
 ```
 
 > If you prefer to use [`espflash`], you can achieve the same result by building the project first and then generating image:


### PR DESCRIPTION
Minor update to the espflash save-image command,

I got this error:

```
$ cargo espflash save-image --merge ESP32 outfile.bin --release
error: Found argument 'outfile.bin' which wasn't expected, or isn't valid in this context

Usage: cargo espflash save-image [OPTIONS] --chip <CHIP> <FILE>

For more information try '--help'
```

They might have changed so that --chip is needed and ESP in capital letters wasn't working for me.