### PR TITLE
Fix install requirement page anchor links

### DIFF
--- a/src/installation/index.md
+++ b/src/installation/index.md
@@ -15,8 +15,8 @@ Please note that you can host the development environment in a [container][use-c
 
 
 [install-rust]: #install-rust
-[risc-v-targets]: #risc-v-targets
-[rics-v-xtensa-targets]: #xtensa-targets
+[risc-v-targets]: #risc-v-targets-only
+[rics-v-xtensa-targets]: #risc-v-and-xtensa-targets
 [use-containers]: #using-containers
 
 


### PR DESCRIPTION
Links were dead when I went to use the book. This hopefully fixes them.