### PR TITLE
fix typo in esp-idf-template.md

### DIFF
--- a/src/writing-your-own-application/generate-project/esp-idf-template.md
+++ b/src/writing-your-own-application/generate-project/esp-idf-template.md
@@ -17,13 +17,13 @@ It should generate a file structure like this:
 ```text
 ├── .cargo
 │   └── config.toml
-└── src
-    └── main.rs
+├── src
+│   └── main.rs
 ├── .gitignore
 ├── build.rs
 ├── Cargo.toml
 ├── rust-toolchain.toml
-├── sdkconfig.defaults
+└── sdkconfig.defaults
 ```
 
 Before going further, let's see what these files are for.


### PR DESCRIPTION
fix typo in that "file structure"