### PR TITLE
subst is not a solution for the long path names on Windows

### DIFF
--- a/src/misc/troubleshooting.md
+++ b/src/misc/troubleshooting.md
@@ -66,11 +66,17 @@ For more information on toolchain overriding, see the [Overrides chapter][overri
 
 ### Long Path Names
 
-When using Windows, you may encounter issues building a new project if using long path names. Follow these steps to substitute the path of your project:
-```powershell
-subst r: <pathToYourProject>
-cd r:\
-```
+When using Windows, you may encounter issues building a new project if using long path names.
+Moreover - and if you are trying to build a `std` application - the build will fail with a hard error if your project path
+is longer than ~ 10 characters.
+
+To workaround the problem, you need to shorten your project name, and move it to the drive root, as in e.g. `C:\myproj`.
+Note also that while using the Windows `subst` utility (as in e.g. `subst r: <pathToYourProject>`) might look like an easy
+solution for using short paths during build while still keeping your project location intact,
+it simply *does not work*, as the short, substitued paths are expanded to their actual (long) locations by the Windows APIs.
+
+Another alternative is to install Windows Subsystem for Linux (WSL), move your project(s) inside the native Linux file partition,
+build inside WSL and only flash the compiled MCU ELF file from outside of WSL.
 
 ### Missing ABI
 

--- a/src/misc/troubleshooting.md
+++ b/src/misc/troubleshooting.md
@@ -73,7 +73,7 @@ is longer than ~ 10 characters.
 To workaround the problem, you need to shorten your project name, and move it to the drive root, as in e.g. `C:\myproj`.
 Note also that while using the Windows `subst` utility (as in e.g. `subst r: <pathToYourProject>`) might look like an easy
 solution for using short paths during build while still keeping your project location intact,
-it simply *does not work*, as the short, substitued paths are expanded to their actual (long) locations by the Windows APIs.
+it simply *does not work*, as the short, substituted paths are expanded to their actual (long) locations by the Windows APIs.
 
 Another alternative is to install Windows Subsystem for Linux (WSL), move your project(s) inside the native Linux file partition,
 build inside WSL and only flash the compiled MCU ELF file from outside of WSL.


### PR DESCRIPTION
As per the discussion [here](https://matrix.to/#/!LdaNPfUfvefOLewEIM:matrix.org/$PDIMESEC-MZl46Mkr9yGKseqFzXr-920GPuwMkYgnjw?via=matrix.org&via=tchncs.de&via=mozilla.org) I think we need to remove this suggestion.

Also users got confused [here](https://github.com/esp-rs/esp-idf-sys/issues/252#issuecomment-1776380500) that `subst` would be a solution.
