### PR TITLE
Update ESP-IDF prerequisites and probe-rs improvements

### DIFF
--- a/src/installation/std-requirements.md
+++ b/src/installation/std-requirements.md
@@ -2,21 +2,23 @@
 
 Regardless of the target architecture, make sure you have the following required tools installed to build [`std`][rust-esp-book-overview-std] applications:
 
-- [`python`][python-website-download]: Required by ESP-IDF
-- [`git`][git-website-download]: Required by ESP-IDF
+- ESP-IDF Prerequisites:
+  - Windows: [`python`][python-website-download] and [`git`][git-website-download]
+  - Linux: See [Linux ESP-IDF prerequisites][esp-idf-linux].
+  - macOS: See [macOS ESP-IDF prerequisites][esp-idf-macos].
 - [`ldproxy`][embuild-github-ldproxy] binary crate: A tool that forwards linker arguments to the actual linker that is also given as an argument to `ldproxy`. Install it by running:
     ```shell
     cargo install ldproxy
     ```
 
-The `std` runtime uses [ESP-IDF][esp-idf-github] (Espressif IoT Development Framework) as hosted environment but, users don't need to install it. ESP-IDF is automatically downloaded and installed by [esp-idf-sys][esp-idf-sys-github], a crate that all `std` projects need to use, when building a `std` application. 
-
-For Linux/MacOS users it's required to have the [ESP-IDF prerequisites][esp-idf-install-guide] installed.
+> ⚠️ **Note**: The `std` runtime uses [ESP-IDF][esp-idf-github] (Espressif IoT Development Framework) as hosted environment but, users don't need to install it. ESP-IDF is automatically downloaded and installed by [`esp-idf-sys`][esp-idf-sys-github], a crate that all `std` projects need to use, when building a `std` application.
 
 [rust-esp-book-overview-std]: ../overview/using-the-standard-library.md
-[python-website-download]: https://www.python.org/downloads/
+[python-website-download]: https://www.python.org/downloads/windows/
 [git-website-download]: https://git-scm.com/downloads
 [embuild-github-ldproxy]: https://github.com/esp-rs/embuild/tree/master/ldproxy
 [esp-idf-sys-github]: https://github.com/esp-rs/esp-idf-sys
 [esp-idf-github]: https://github.com/espressif/esp-idf
-[esp-idf-install-guide]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-macos-setup.html#step-1-install-prerequisites
+[esp-idf-linux]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-macos-setup.html#for-linux-users
+[esp-idf-macos]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-macos-setup.html#for-macos-users
+

--- a/src/tooling/debugging/probe-rs.md
+++ b/src/tooling/debugging/probe-rs.md
@@ -33,7 +33,7 @@ The flashing command can be set as a custom Cargo runner by adding the following
 
 ```toml
 [target.'cfg(any(target_arch = "riscv32", target_arch = "xtensa"))']
-runner = "probe-rs run --chip esp32c3 --format idf"
+runner = "probe-rs run --chip esp32c3"
 ```
 
 With this configuration, you can flash and monitor your application using `cargo run`.
@@ -67,11 +67,11 @@ There is a `probe-rs` extension in VS Code, see `probe-rs` [VS Code documentatio
             "coreConfigs": [
                 {
                     "coreIndex": 0,
-                    "programBinary": "./target/riscv32imc-unknown-none-elf/debug/${workspaceFolderBasename}", //!MODIFY
+                    "programBinary": "target/riscv32imc-unknown-none-elf/debug/${workspaceFolderBasename}", //!MODIFY
                     "rttEnabled": true,
                     "rttChannelFormats": [
                         {
-                            "channelNumber": "0",
+                            "channelNumber": 0,
                             "dataFormat": "String",
                             "showTimestamp": true,
                         }
@@ -88,11 +88,11 @@ There is a `probe-rs` extension in VS Code, see `probe-rs` [VS Code documentatio
             "coreConfigs": [
                 {
                     "coreIndex": 0,
-                    "programBinary": "./target/riscv32imc-unknown-none-elf/debug/${workspaceFolderBasename}", //!MODIFY
+                    "programBinary": "target/riscv32imc-unknown-none-elf/debug/${workspaceFolderBasename}", //!MODIFY
                     "rttEnabled": true,
                     "rttChannelFormats": [
                         {
-                            "channelNumber": "0",
+                            "channelNumber": 0,
                             "dataFormat": "String",
                             "showTimestamp": true,
                         }


### PR DESCRIPTION
- Clarify which ESP-IDF requirements are needed for every OS
- Update some minor probe-rs stuff:
  - We no longer need the `--format idf` arg
  - `"channelNumber": "0",` may throw an error because it's not expecting a String.