### PR TITLE
additional explanations

### DIFF
--- a/src/installation/riscv.md
+++ b/src/installation/riscv.md
@@ -23,7 +23,7 @@ To build Rust applications for the Espressif chips based on `RISC-V` architectur
       rustup target add riscv32imac-unknown-none-elf # For ESP32-C6 and ESP32-H2
       ```
 
-      This target is currently [Tier 2][rust-lang-book--platform-support-tier2]. Note the different flavors of `riscv32` target in Rust covering different [`RISC-V` extensions][wiki-riscv-standard-extensions].  
+      This target is currently [Tier 2][rust-lang-book--platform-support-tier2]. Note the different flavors of `riscv32` target in Rust covering different [`RISC-V` extensions][wiki-riscv-standard-extensions].
 
     - For `std` applications:
 

--- a/src/installation/riscv.md
+++ b/src/installation/riscv.md
@@ -7,6 +7,14 @@ To build Rust applications for the Espressif chips based on `RISC-V` architectur
     ```shell
     rustup toolchain install nightly --component rust-src
     ```
+
+    The above command downloads the rust source code. `rust-src` contains things like the std-lib, core-lib and build-config files.  
+    Downloading the `rust-src` is important because of two reasons : 
+    - **Determinism** - You get the chance to inspect the internals of the core and std library. If you are building software that needs to be determinate, you may need to inspect the libraries that you are using.  
+    - **Building custom targets** - The `rustc` uses the `rust-src` to create the components of a new custom-target. If you are targeting a triple-target that is not yet supported by rust, it becomes essential to download the `rust-src`.
+
+   For more info on custom targets, read this [Chapter][embedonomicon-creating-a-custom-target] from the [Embedonomicon][embedonomicon-official-book].
+
 2. Set the target:
     - For `no_std` (bare-metal) applications, run:
 
@@ -15,7 +23,7 @@ To build Rust applications for the Espressif chips based on `RISC-V` architectur
       rustup target add riscv32imac-unknown-none-elf # For ESP32-C6 and ESP32-H2
       ```
 
-      This target is currently [Tier 2][rust-lang-book--platform-support-tier2]. Note the different flavors of `riscv32` target in Rust covering different [`RISC-V` extensions][wiki-riscv-standard-extensions].
+      This target is currently [Tier 2][rust-lang-book--platform-support-tier2]. Note the different flavors of `riscv32` target in Rust covering different [`RISC-V` extensions][wiki-riscv-standard-extensions].  
 
     - For `std` applications:
 
@@ -40,3 +48,5 @@ Now you should be able to build and run projects on Espressif's `RISC-V` chips.
 [cargo-book-unstable-features]: https://doc.rust-lang.org/cargo/reference/unstable.html
 [rust-esp-book-write-app-generate-project]: ../writing-your-own-application/generate-project/index.md
 [rust-esp-book-std-requirements]: ./std-requirements.md
+[embedonomicon-creating-a-custom-target]: https://docs.rust-embedded.org/embedonomicon/custom-target.html
+[embedonomicon-official-book]: https://docs.rust-embedded.org/embedonomicon/


### PR DESCRIPTION
Explanations have been added. They explain why 'rust-src' needs to be downloaded during the environment set-up described in chapter 3.2.

below is a screenshot of the rendered output :
![Screenshot 2023-12-21 at 01-34-41 RISC-V targets only - The Rust on ESP Book](https://github.com/esp-rs/book/assets/52859388/d5acb805-e011-4ca4-b99e-296716366f7e)


PS. I have just started reading this book. I am noob. I will be adding noob-like explanations to the book ( i.e explanations that I found necessary during my journey.) ✌🏼
