### PR TITLE
C3 rev correction

### DIFF
--- a/src/tooling/debugging/index.md
+++ b/src/tooling/debugging/index.md
@@ -19,8 +19,8 @@ Refer to the table below to see which chip is supported in every debugging metho
 Some of our recent products contain the `USB-JTAG-SERIAL` peripheral that allows for debugging without any external hardware debugger. More info on configuring the interface can be found in the official documentation for the chips that support this peripheral:
 - [ESP32-C3][esp32c3-docs]
     - The availability of built-in JTAG interface depends on the ESP32-C3 revision:
-      - Revisions older than 3 **don't** a have built-in JTAG interface.
-      - Revisions 3 (and newer) **do** have a built-in JTAG interface, and you don't have to connect an external device to be able to debug.
+      - Revisions older than 0.3 **don't** have a built-in JTAG interface.
+      - Revisions 0.3 (and newer) **do** have a built-in JTAG interface, and you don't have to connect an external device to be able to debug.
 
     To find your ESP32-C3 revision, run:
     ```shell

--- a/src/troubleshooting/index.md
+++ b/src/troubleshooting/index.md
@@ -47,7 +47,7 @@ solution for using short paths during build while still keeping your project loc
 it simply *does not work*, as the short, substituted paths are expanded to their actual (long) locations by the Windows APIs.
 
 Another alternative is to install Windows Subsystem for Linux (WSL), move your project(s) inside the native Linux file partition,
-build inside WSL and only flash the compiled MCU ELF file from outside of WSL.
+build inside WSL and only flash the compiled MCU ELF file from outside of WSL. A third is to use USB/IP to show the development board within WSL itself, and flash it from there <sub>[ESP32-WSL](https://github.com/lure23/ESP32-WSL)</sub>. Pick your poison.
 
 ### Missing ABI
 


### PR DESCRIPTION
This is the only place in the awesome book that had me doubting.. Perhaps what is written as "revision 3" should be "revision 0.3"?

In the book itself, [this line](https://github.com/esp-rs/book/blob/29745e653aef79b0664ee6c27c1fc7f1e38981c7/src/writing-your-own-application/generate-project/esp-idf-template.md?plain=1#L105) lists a C3 revision as "0.3".

I have a 0.4: 

```
$ cargo espflash board-info
[2024-01-07T21:06:35Z INFO ] Serial port: '/dev/ttyUSB0'
[2024-01-07T21:06:35Z INFO ] Connecting...
[2024-01-07T21:06:35Z INFO ] Using flash stub
Chip type:         esp32c3 (revision v0.4)       <<-----
Crystal frequency: 40MHz
[...]
```

Please verify. I am not in the position to know, where the JTAG became built-in, but I do hope my 0.4 board has it.