### PR TITLE
Update riscv-and-xtensa.md

### DIFF
--- a/src/installation/riscv-and-xtensa.md
+++ b/src/installation/riscv-and-xtensa.md
@@ -30,7 +30,7 @@ espup install
 `espup` will create an export file that contains some environment variables required to build projects.
 
 On Windows (`%USERPROFILE%\export-esp.ps1`)
-  - There is **no need** to execute the file for Windows users. It is only created to show the modified environment variables.
+  - If all goes well, there is **no need** to execute the file for Windows users. However if espup install is not run as administrator, you may still need to run the file as a command in every shell before compiling will work.
 
 On Unix-based systems (`$HOME/export-esp.sh`). There are different ways of sourcing the file:
 - Source this file in every terminal:


### PR DESCRIPTION
The old statement was incorrect, because if the installer is not run as administrator, it fails to permanently set the environment variables without telling you. I have also submitted a PR to display a clearer error message in espup.