### PR TITLE
Fix broken url of esp-hal example

### DIFF
--- a/src/writing-your-own-application/nostd.md
+++ b/src/writing-your-own-application/nostd.md
@@ -13,7 +13,7 @@ The training contains:
    * [A button example][button]
    * [A button with an interrupt example][button-interrupt]
 
-> ⚠️ **Note**: There are several examples covering the use of specific peripherals under the [`example`][esp-hal-examples] folder [`esp-hal`][esp-hal]. To check if a device is compatible with a given example, check the metadata comments above the imports, which will list all supported devices following the `//% CHIPS:` designator. If this metadata is not present, then the example will work on any device supported by esp-hal.
+> ⚠️ **Note**: There are several examples covering the use of specific peripherals under the [`examples`][esp-hal-examples] folder [`esp-hal`][esp-hal]. For running instructions and device compatibility for a given example, refer to the [`examples` README][examples-readme].
 
 
 

--- a/src/writing-your-own-application/nostd.md
+++ b/src/writing-your-own-application/nostd.md
@@ -27,3 +27,4 @@ The training contains:
 [button-interrupt]: https://github.com/esp-rs/no_std-training/tree/main/intro/button-interrupt
 [esp-hal]: https://github.com/esp-rs/esp-hal
 [esp-hal-examples]: https://github.com/esp-rs/esp-hal/tree/main/examples
+[examples-readme]: https://github.com/esp-rs/esp-hal/blob/main/examples/README.md

--- a/src/writing-your-own-application/nostd.md
+++ b/src/writing-your-own-application/nostd.md
@@ -13,7 +13,7 @@ The training contains:
    * [A button example][button]
    * [A button with an interrupt example][button-interrupt]
 
-> ⚠️ **Note**: There are several examples covering the use of specific peripherals under the examples' folder [`esp-hal`][esp-hal]. To check if a device is compatible with a given example, check the metadata comments above the imports, which will list all supported devices following the `//% CHIPS:` designator. If this metadata is not present, then the example will work on any device supported by esp-hal.
+> ⚠️ **Note**: There are several examples covering the use of specific peripherals under the [`example`][esp-hal-examples] folder [`esp-hal`][esp-hal]. To check if a device is compatible with a given example, check the metadata comments above the imports, which will list all supported devices following the `//% CHIPS:` designator. If this metadata is not present, then the example will work on any device supported by esp-hal.
 
 
 
@@ -26,4 +26,4 @@ The training contains:
 [button]: https://github.com/esp-rs/no_std-training/tree/main/intro/button
 [button-interrupt]: https://github.com/esp-rs/no_std-training/tree/main/intro/button-interrupt
 [esp-hal]: https://github.com/esp-rs/esp-hal
-[esp32c3-hal-examples]: https://github.com/esp-rs/esp-hal/tree/main/esp32c3-hal/examples
+[esp-hal-examples]: https://github.com/esp-rs/esp-hal/tree/main/examples

--- a/src/writing-your-own-application/nostd.md
+++ b/src/writing-your-own-application/nostd.md
@@ -13,7 +13,9 @@ The training contains:
    * [A button example][button]
    * [A button with an interrupt example][button-interrupt]
 
-> ⚠️ **Note**: There are several examples covering the use of specific peripherals under the examples' folder of every SoC [`esp-hal`][esp-hal]. E.g. [`esp32c3-hal/examples`][esp32c3-hal-examples]
+> ⚠️ **Note**: There are several examples covering the use of specific peripherals under the examples' folder [`esp-hal`][esp-hal]. To check if a device is compatible with a given example, check the metadata comments above the imports, which will list all supported devices following the `//% CHIPS:` designator. If this metadata is not present, then the example will work on any device supported by esp-hal.
+
+
 
 [no-std-book]: https://esp-rs.github.io/no_std-training/
 [no-std-repository]: https://github.com/esp-rs/no_std-training


### PR DESCRIPTION
`example` folder under each SOC's folder was moved to `examples`, the url pointed to `esp32c3-hal/examples` is broken. This PR removes the url, adds a description of how to check example compatibility of specific SOC.