### PR TITLE
Fix VSCode check all targets parameter name

### DIFF
--- a/src/tooling/visual-studio-code.md
+++ b/src/tooling/visual-studio-code.md
@@ -26,7 +26,7 @@ If you are developing for a target that doesn't have `std` support, Rust Analyze
 
 ```json
 {
-  "rust-analyzer.checkOnSave.allTargets": false
+  "rust-analyzer.check.allTargets": false
 }
 ```
 


### PR DESCRIPTION
The rust-analyzer.checkOnSave.allTargets parameter name is deprecated; VSCode highlights this as an unknown parameter (though it is still accepted by some versions of rust-analyzer). The new parameter name is rust-analyzer.check.allTargets.