### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 title        = "The Rust on ESP Book"
 description  = "A comprehensive guide on using the Rust programming language with Espressif SoCs and modules"
-multilingual = false
 language     = "en"
 
 [rust]


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10