### PR TITLE
Application Developement improvements

### DIFF
--- a/src/application-development/alloc.md
+++ b/src/application-development/alloc.md
@@ -1,4 +1,4 @@
-# Alloc
+# Allocating Memory
 
 In a `no_std` environment, the [`alloc`][alloc] crate is available as an option for heap allocation. It can be useful when working with crates that require alloc or when using dynamic collections like `Vec`.
 
@@ -18,15 +18,16 @@ build-std = ["alloc", "core"] # added alloc here
 3. Use `alloc` crate in your application
 ```rust
 // main.rs
-
+#[main]
 extern crate alloc;
 ```
 
 4. Initialize a global heap allocator providing a heap of the given size in bytes with the provided macro:
 ```rust
 // main.rs
+fn main() -> ! {
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
-esp_alloc::heap_allocator!(size: 72 * 1024);
 ```
 
 or when more customization is required using the function:
@@ -61,11 +62,11 @@ heap_allocator!(#[link_section = ".dram2_uninit"] size: 64000);
 Our chips have a few hundred kilobytes of internal RAM, which could be insufficient for some applications. The ESP32, ESP32-S2, and ESP32-S3 have the ability to use virtual addresses for external PSRAM (Psuedostatic RAM) memory. The external memory is usable is the same way as internal data RAM, with certain restrictions. The biggest restriction is that the atomic instructions do not work
 correctly when the memory they access is located in PSRAM. This means that
 the allocator must not be used to allocate `Atomic*` types - either directly
-or indirectly. ESP32 restrictions can be found [here]. 
+or indirectly. ESP32 restrictions can be found [here].
 
 ### Allocator Considerations
 
-You can only have **one global allocator** but the allocator can use multiple regions (e.g. PSRAM, internal RAM or even multiple blocks of them). You can use multiple allocators with the nightly-feature "allocator api" and with [`allocator api2`][allocator api2], which [`esp-alloc`][esp-alloc] implements.
+You can only have **one global allocator** but the allocator can use multiple regions (e.g. PSRAM, internal RAM or even multiple blocks of them). You can use multiple allocators with the nightly-feature `allocator api` and with [`allocator api2`][allocator api2], which [`esp-alloc`][esp-alloc] implements.
 
 [esp-alloc]: https://crates.io/crates/esp-alloc
 [alloc]: https://doc.rust-lang.org/alloc/

--- a/src/application-development/async.md
+++ b/src/application-development/async.md
@@ -1,6 +1,12 @@
-# Async
+# Async Options
 
-This section does not serve as an async tutorial or teaching material. For these purposes, visit [official async-book]. 
+> ⚠️ **Note**:  This section does not serve as an async tutorial or teaching material. For these purposes, visit [official async-book].
+
+`esp-hal` provides blocking and async API for most of the supported drivers. For more information and to get started, check our `examples` in the [esp-hal-package].
+
+## Embassy
+
+[Embassy] is an asynchronous (async) framework designed specifically for embedded Rust development; its [embassy-executor] crate provides an `async/await` executor which executes a fixed number of tasks, statically allocated at startup, though more can be added later. To spawn more tasks later, you may keep copies of the `Spawner` (it is `Copy`), for example by passing it as an argument to the initial tasks. For more information about `embassy` visit [Embassy book].
 
 The [`esp-hal-embassy`][esp-hal-embassy] crate provides integration between the [`esp-hal`][esp-hal] and the [Embassy] asynchronous framework. It provides support for:
 
@@ -9,16 +15,11 @@ The [`esp-hal-embassy`][esp-hal-embassy] crate provides integration between the 
 3. Embassy time driver
 4. Timer waiter queue
 
-`esp-hal` provides blocking and async API for most of the supported drivers. For more information and to get started, check our `examples` in the [esp-hal-package].
-
-## Embassy
-
-[Embassy] is an asynchronous (async) framework designed specifically for embedded Rust development; its [embassy-executor] crate provides an `async/await` executor which executes a fixed number of tasks, statically allocated at startup, though more can be added later. To spawn more tasks later, you may keep copies of the `Spawner` (it is `Copy`), for example by passing it as an argument to the initial tasks. For more information about `embassy` visit [Embassy book].
 
 
 ## RTIC
 
-[Real-Time Interrupt-driven Concurrency (RTIC)] is a concurrency framework for building real-time systems. Currently, the ESP32-C3 and the ESP32-C6 are supported.
+[Real-Time Interrupt-driven Concurrency (RTIC)] is a concurrency framework for building real-time systems. Currently, only ESP32-C3 and ESP32-C6 are supported.
 
 
 [official async-book]: https://rust-lang.github.io/async-book/

--- a/src/application-development/bootloader.md
+++ b/src/application-development/bootloader.md
@@ -1,12 +1,19 @@
-# Bootloader
+# Building a Custom ESP-IDF Bootloader
 
-The `espflash` includes pre-built ESP-IDF [bootloaders] that are compiled using the default settings, making it easy to get started without additional configuration. However, if you require more advanced functionality or custom settings, you will need to build the bootloader yourself to tailor it to your specific needs. To do that, you need to:
-1. [Set up esp-idf].
+The `espflash` and `cargo-espflash` include pre-built ESP-IDF [bootloaders] that are compiled using the default settings, making it easy to get started without additional configuration. However, if you require more advanced functionality or custom settings, you will need to build the bootloader yourself to tailor it to your specific needs.
+
+To build a custom ESP-IDF bootloader:
+1. [Install ESP-IDF][esp-idf-install].
 2. Create a new project or go to an already existing one.
-3. Make desired changes using `idf.py menuconfig`.
-4. Re-build with `idf.py set-target <CHIP_TARGET> build`.
-5. Use the built bootloader binary with `espflash flash --bootloader <your_esp_idf_project/build/bootloader/bootloader.bin>` command.
+   - Using any examples under the `esp-idf/examples` directory is the easiest way.
+3. Make desired changes using `idf.py menuconfig` or editing the `sdkconfig` file.
+   - See [Configuration Options Reference][config-reference] for more information.
+4. Build the bootloader with `idf.py set-target <CHIP_TARGET> build bootloader`.
+   - The resulting booloader binary will be placed under `build/bootloader/bootloader.bin`.
+5. Use the built bootloader binary in `espflash/cargo-espflash` with the `--bootloader` flag or with the [configuration file][espflash-config-file].
 
 
 [bootloaders]: https://github.com/esp-rs/espflash/tree/main/espflash/resources/bootloaders
-[Set up esp-idf]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/index.html#manual-installation
+[esp-idf-install]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/index.html#manual-installation
+[config-reference]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig-reference.html#configuration-options-reference
+[espflash-config-file]: https://github.com/esp-rs/espflash/tree/main/espflash#configuration-file

--- a/src/application-development/configuration.md
+++ b/src/application-development/configuration.md
@@ -6,7 +6,7 @@ The [`esp-config`][esp-config] crate provides a way to manage configuration sett
 
 The full list of available options can be found in the documentation of the `esp-*` crate you are using.
 
-For example, in esp-hal if you want to place a function in your code in the RAM (`ESP_HAL_CONFIG_PLACE_SPI_DRIVER_IN_RAM`), which is set to `false` as default, you need to create an environment variable with the same name and modify its value:
+For example, in `esp-hal` if you want to place a function in your code in the RAM (`ESP_HAL_CONFIG_PLACE_SPI_DRIVER_IN_RAM`), which is set to `false` as default, you need to create an environment variable with the same name and modify its value:
 
 ```toml
 # .cargo/config.toml
@@ -17,7 +17,7 @@ ESP_HAL_CONFIG_PLACE_SPI_DRIVER_IN_RAM="true"
 
 After modifying the `.cargo/config.toml` and `[env]` section, **clean build** is recommended.
 
-> ⚠️ **Note**: Setting the `env-vars` on the command line will have precedence over env section.
+> ⚠️ **Note**: Setting the environment variables on the command line will have precedence over env section.
 
 For more information see [esp-config] README.
 

--- a/src/application-development/index.md
+++ b/src/application-development/index.md
@@ -2,8 +2,8 @@
 
 This chapter covers essential topics for developing applications:
 
- - [Bootloader](./bootloader.md) (startup)
- - [Configuration](./configuration.md) (dynamic settings)
- - [Logging](./logging.md) (debugging and monitoring)
- - [Alloc](./alloc.md) (heap strategies in resource-constrained targets)
- - [Async](./async.md) (event-driven patterns without OS threads e.g., embassy)
+ - [Building a Custom ESP-IDF Bootloader](./bootloader.md)
+ - [Using `esp-config`](./configuration.md)
+ - [Logging](./logging.md)
+ - [Allocating Memory](./alloc.md)
+ - [Async Options](./async.md)

--- a/src/application-development/logging.md
+++ b/src/application-development/logging.md
@@ -1,14 +1,14 @@
 # Logging
 
-​Logging is a crucial aspect of embedded systems development, providing visibility into the system's behavior and aiding in debugging and monitoring. In the Rust ecosystem for ESP devices, two prominent logging frameworks are commonly used: the [`log`][log] crate and [`defmt`][defmt].
+​Logging is a crucial aspect of embedded systems development, providing visibility into the system's behavior and aiding in debugging and monitoring. In the Rust ecosystem for Espressif devices, two prominent logging frameworks are commonly used: [`defmt`][defmt] and [`log`][log].
 
-## The `defmt` Framework
+## `defmt`
 
-[defmt] is a highly efficient logging framework designed for resource-constrained environments, such as embedded systems. It offers compact, binary-encoded log messages, reducing the overhead associated with traditional string-based logging.​ For more information about see [defmt-documentation].
+[`defmt`][defmt] is a highly efficient logging framework designed for resource-constrained environments, such as embedded systems. It offers compact, binary-encoded log messages, reducing the overhead associated with traditional string-based logging.​ For more information about see [`demft` documentation][defmt-documentation].
 
 ### Integrating `defmt` with `probe-rs`
 
-1. Add dependencies to your `Cargo.toml`:
+1. Add the required dependencies to your `Cargo.toml`:
 ```toml
 defmt            = "0.3.10"
 esp-hal          = { version = "1.0.0-beta.0", features = ["defmt", "esp32c6"] }
@@ -20,14 +20,14 @@ rtt-target       = { version = "0.6.1", features = ["defmt"] }
 [env]
 DEFMT_LOG="info" # Set desired log level
 ```
-For more details about filtering see [filtering].
+   - For more details about filtering see [filtering].
 
 3. Initialize the Logger:
 ```rust
 use defmt::info;
 #[main]
 fn main() -> ! {
-    
+
     // Initialize RTT for use with defmt
     rtt_target::rtt_init_defmt!();
     info!("Hello world!");
@@ -39,14 +39,12 @@ fn main() -> ! {
 
 `esp-println` can be configured to work seamlessly with `defmt`, providing a global logger that outputs defmt-encoded messages. To set this up:​
 
-1. Add dependencies to your `Cargo.toml`:
+1. Add the required dependencies to your `Cargo.toml`:
 ```toml
 defmt            = "0.3.10"
 esp-hal          = { version = "1.0.0-beta.0", features = ["defmt", "esp32c6"] }
 esp-println      = { version = "0.13.0", features = ["defmt-espflash", "esp32c6"] }
 ```
-Ensure you specify the feature corresponding to your target device (e.g. `esp32c6` for ESP32-C6).
-
 2. Set log level in your `.config.toml`:
 ```toml
 [env]
@@ -54,20 +52,20 @@ DEFMT_LOG="info" # Set desired log level
 ```
 For more details about filtering see [filtering].
 
-3. Minimal example:
+3. Build the required dependencies and use the logger:
 ```rust
 use defmt::info;
 use esp_println as _;
 
 #[main]
 fn main() -> ! {
-    
+
     info!("Hello world!");
     // ...
 }
 ```
 
-## The `log` crate
+## `log`
 
 The [`log`][log] crate is a widely adopted logging facade in the Rust community. It defines a set of macros (`info!`, `warn!`, `error!`, etc.) to capture log messages at various levels.
 
@@ -81,7 +79,6 @@ esp-hal          = { version = "1.0.0-beta.0", features = ["esp32c6"] }
 esp-println      = { version = "0.13.0", features = ["esp32c6", "log"] }
 log              = { version = "0.4.21" }
 ```
-Ensure you specify the feature corresponding to your target device (e.g. `esp32c6` for ESP32-C6).
 
 2. Set log level in your `.config.toml`:
 ```toml
@@ -89,13 +86,13 @@ Ensure you specify the feature corresponding to your target device (e.g. `esp32c
 ESP_LOG="info" # Set desired log level
 ```
 
-3. Initialize the Logger:
+3. Initialize the logger:
 ```rust
 use log::info;
 
 #[main]
 fn main() -> ! {
-    
+
     // Set up esp-println as the logger
     esp_println::logger::init_logger_from_env();
     info!("Hello world!");
@@ -105,6 +102,5 @@ fn main() -> ! {
 
 [log]: https://crates.io/crates/log
 [defmt]: https://crates.io/crates/defmt
-[esp-println]: https://crates.io/crates/esp-println
 [defmt-documentation]: https://defmt.ferrous-systems.com/introduction
 [filtering]: https://defmt.ferrous-systems.com/filtering#filtering

--- a/src/frequently-asked-questions.md
+++ b/src/frequently-asked-questions.md
@@ -90,7 +90,7 @@ cargo.target = "riscv32imac-unknown-none-elf"
 - Cargo provides some default profiles; we recommend using the [`release` profile][release-profile] as it optimizes and removes debug symbols.
 - Cargo allows different [profile settings][profile-settings-cargo], which can make a difference in the resulting size of the artifact.
   - See [Optimizations: the speed size tradeoff][embedded-book-tradeoffs] of The Embedded Rust Book.
-- Be careful when using external dependencies, as they can increase the size of your resulting artifact
+- Be careful when using external dependencies, as they can increase the size of your resulting artifact.
 - Filter log messages if they are not going to be useful or read.
 
 [embedded-book-tradeoffs]: https://docs.rust-embedded.org/book/unsorted/speed-vs-size.html
@@ -175,7 +175,7 @@ Wokwi offers a VS Code extension that allows you to simulate a project directly 
 For more information, see [Wokwi documentation][wokwi-vscode].
 You can also debug your code using the VS Code debugger; see [Debugging your code][wokwi-debugging].
 
-When using [`esp-generate`][esp-generate], there is a option that generates the required files to use Wokwi VS Code extension.
+When using [`esp-generate`][esp-generate], there is an option that generates the required files to use Wokwi VS Code extension.
 
 
 [wokwi-vscode]: https://docs.wokwi.com/vscode/getting-started
@@ -184,7 +184,7 @@ When using [`esp-generate`][esp-generate], there is a option that generates the 
 
 #### Using `wokwi-server`
 
-[`wokwi-server`][wokwi-server] is a CLI tool for launching a Wokwi simulation of your project. I.e., it allows you
+[`wokwi-server`][wokwi-server] is a CLI tool for launching a Wokwi simulation of your project. It allows you
 to build a project on your machine, or in a container, and simulate the resulting binary.
 
 [`wokwi-server`][wokwi-server] also allows simulating your resulting binary on other Wokwi projects, with more hardware parts other than the chip itself. See the corresponding [section of the `wokwi-server`][wokwi-server-custom] README for detailed instructions.
@@ -224,7 +224,7 @@ We can use [`cargo-espflash`][cargo-espflash] to generate it:
 cargo espflash save-image --chip esp32 --merge <OUTFILE> --release
 ```
 
-If you prefer to use [`espflash`][espflash], you can achieve the same result by building the project first and then generating image:
+If you prefer to use [`espflash`][espflash], you can achieve the same result by building the project first and then generating an image:
 
 ```shell
 cargo build --release

--- a/src/getting-started/toolchain.md
+++ b/src/getting-started/toolchain.md
@@ -114,10 +114,8 @@ The forked compiler can coexist with the standard Rust compiler, allowing both t
 [rustup-overrides]: https://rust-lang.github.io/rustup/overrides.html
 [llvm-github-fork-upstream issue]: https://github.com/espressif/llvm-project/issues/4
 
-#### Other Installation Methods for Xtensa Targets
+#### Building the Rust Compiler with Xtensa Support from Source
 
-- Using [`rust-build`][rust-build] installation scripts. This was the recommended in the past, but now the installation scripts are feature frozen and all new features will only be included in `espup`. See the repository README for instructions.
-- Building the Rust compiler with Xtensa support from source. This process is computationally expensive and can take one or more hours to complete depending on your system. It isn't recommended unless there is a major reason to go for this approach. Here is the repository to build it from source: [`esp-rs/rust` repository][esp-rs-rust].
+This process is computationally expensive and can take one or more hours to complete depending on your system. It isn't recommended unless there is a major reason to go for this approach. Here is the repository to build it from source: [`esp-rs/rust` repository][esp-rs-rust].
 
-[rust-build]: https://github.com/esp-rs/rust-build#download-installer-in-bash
 [esp-rs-rust]: https://github.com/esp-rs/rust

--- a/src/getting-started/toolchain.md
+++ b/src/getting-started/toolchain.md
@@ -50,8 +50,6 @@ Now you should be able to build and run projects on Espressif's RISC-V chips.
 [rustup-book-components]: https://rust-lang.github.io/rustup/concepts/components.html
 [rust-lang-book--platform-support-tier2]: https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-2
 [wiki-riscv-standard-extensions]: https://en.wikichip.org/wiki/risc-v/standard_extensions
-[embedonomicon-creating-a-custom-target]: https://docs.rust-embedded.org/embedonomicon/custom-target.html
-[embedonomicon-official-book]: https://docs.rust-embedded.org/embedonomicon/
 
 ### Xtensa Devices
 

--- a/src/getting-started/tooling/esp-generate.md
+++ b/src/getting-started/tooling/esp-generate.md
@@ -2,7 +2,7 @@
 
 [`esp-generate`][esp-generate] is a template generation tool that assists users in creating a functional project with most of their desired configurations pre-applied.
 
-## Instalaltion
+## Installation
 To install `esp-generate`:
 
 ```shell
@@ -19,7 +19,7 @@ You can also directly download pre-compiled [release binaries][release-binaries]
 To launch the TUI and select your configuration options, run:
 
 ```shell
-esp-generate --chip esp32c3 your-project
+esp-generate --chip esp32c3 your-project-name
 ```
 
 Replace the chip and project name accordingly.
@@ -27,7 +27,7 @@ Replace the chip and project name accordingly.
 If you prefer not to use the TUI, you can specify options directly with the `-o/--options` flag. Additionally, using the `--headless` flag will prevent the TUI from launching:
 
 ```shell
-esp-generate --chip esp32 -o alloc -o wifi --headless your-project
+esp-generate --chip esp32 -o alloc -o wifi --headless your-project-name
 ```
 
 Adjust the options as needed for your project. See [Available Options][available-options] section of the README.
@@ -74,7 +74,7 @@ Some of the options may add some other files to your generated project:
   - `.vscode/extensions.json`
     - Lists recommended VS Code extensions
   - `.vscode/settings.json`
-    - Contains reccomended VS Code settings
+    - Contains recommended VS Code settings
 
 [esp-generate]: https://github.com/esp-rs/esp-generate
 [available-options]: https://github.com/esp-rs/esp-generate?tab=readme-ov-file#available-options
@@ -95,7 +95,8 @@ Building and running the code is as easy as:
 cargo run --release
 ```
 
-This builds your application, flashes it to the target device and will open a serial monitor.
+This builds your application, flashes it to the target device and opens a serial monitor. The command uses the runner configuration in `.cargo/config.toml` that was automatically set up by `esp-generate`.
+
 <!-- TODO: Shall we explain the fron and backend options here? -->
 
 

--- a/src/getting-started/tooling/espflash.md
+++ b/src/getting-started/tooling/espflash.md
@@ -70,11 +70,6 @@ To install `cargo-espflash`, execute the following command:
 cargo install cargo-espflash --locked
 ```
 
-> ⚠️ **Note**: in Unix systems, we use the [`vendored-openssl` Cargo feature][vendored-ssl] which may require additional tools such as `perl` and `make`. To disable this feature, use:
-> ```shell
-> OPENSSL_NO_VENDOR=1 cargo install cargo-espflash
-> ```
-
 ### Building, Flashing and Monitoring an Application
 
 This command must be run within a Cargo project, ie. a directory containing a `Cargo.toml` file. For example, to build an application named 'blinky', flash the resulting binary to a device, and then subsequently start a serial monitor:

--- a/src/introduction/hardware-overview.md
+++ b/src/introduction/hardware-overview.md
@@ -10,7 +10,7 @@ The Espressif portfolio is based on two different system architectures:
 - [Xtensa][xtensa-architecture]: The ESP32 and ESP32-S series are based on the Xtensa architecture.
 - [RISC-V][riscv-architecture]: The ESP32-C and ESP32-H series are based on the RISC-V architecture.
 
-We won't go into the details or differences between the two architectures here. Rust's official support differs between the two architectures. Xtensa is not yet officially supported, though we matain a fork that adds suport for it and are actively working to upstream our patches, for more information, see the [Note on "What `espup` install"][note-espup] section.
+We won't go into the details or differences between the two architectures here. Rust's official support differs between the two architectures. Xtensa is not yet officially supported, though we maintain a fork that adds support for it and are actively working to upstream our patches, for more information, see the [Note on "What `espup` installs"][note-espup] section.
 
 Feel free to refer to the [Technical Documentation][espressif-docs] for more information about the different SoCs.
 

--- a/src/introduction/startup-flow.md
+++ b/src/introduction/startup-flow.md
@@ -4,7 +4,7 @@ In order to boot an application, Espressif devices use 2 bootloaders:
 - First Stage Bootloader (ROM Bootloader): Sets up architecture-specific registers, checks the [boot mode][boot-mode] and reset reason, and loads the second stage bootloader.
 - Second Stage Bootloader: Loads the [partition table][partition-table] and your application.
 
-The second stage bootloader is required as it allows OTA support (first stage bootloader only load applications from a fixed offset in Flash) and also for Flash encryption and secure boot.
+The second stage bootloader is required as it allows OTA support (the first stage bootloader only loads applications from a fixed offset in Flash) and also enables Flash encryption and secure boot.
 
 For more information about the startup process, please check [ESP-IDF documentation][esp-idf-startup]. However, note that some aspects may be ESP-IDF specific.
 
@@ -14,19 +14,22 @@ For more information about the startup process, please check [ESP-IDF documentat
 
 ### Second Stage Bootloader
 
+At the moment, only ESP-IDF Bootloader is supported as a second stage bootloader, this will change in the future as we plan to add support for other bootloaders.
+
 #### ESP-IDF Bootloader
 
-Uses the [ESP image format][esp-image-format], see more information in [ESP-IDF documentation][esp-idf-second-stage-bootloader]
+Uses the [ESP image format][esp-image-format], see more information in [ESP-IDF documentation][esp-idf-second-stage-bootloader]. The ESP-IDF bootloader is used with a partition table to know where to place the binary.
 
 [esp-idf-second-stage-bootloader]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32c6/api-guides/startup.html#second-stage-bootloader
 
-## Partition Tables
+##### Partition Tables
 
 Flash memory of the Espressif devices can store multiple applications along with various types of data, such as calibration data, filesystems, and parameter storage. To manage this, a partition table is flashed at the default offset device.
 
-The second stage bootloader will know where to place the binary by looking at the partition table. Each entry in the partition table has a name (label), type (app, data, or something else), subtype and the offset in flash where the partition is loaded.
+The ESP-IDF second stage bootloader will know where to place the binary by looking at the partition table. Each entry in the partition table has a name (label), type (`app`, `data`, or something else), subtype and the offset in flash where the partition is loaded.
 
 When working with [`espflash`][espflash], if you don't provide a second stage bootloader or partition table, `espflash` will use a default bootloader and partition table, but you can also create a [custom partition table][custom-partition-table].
+
 
 [esp-image-format]: https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/firmware-image-format.html
 [espflash]: ../getting-started/tooling/espflash.md

--- a/src/preface.md
+++ b/src/preface.md
@@ -2,7 +2,7 @@
 
 # Preface
 
-Welcome to a comprehensive guide to using the `esp-rs` ecosystem, created for embedded Rust development on Espressif products. You will find everything you need to get started and build real-world applications, from setting up your development environment to writing and debugging embedded code in Rust. We will also touch on other important aspects such as our tools, give an overview of our software product architecture, and teach how you can contribute to our project. 
+Welcome to a comprehensive guide to using the `esp-rs` ecosystem, created for embedded Rust development on Espressif products. You will find everything you need to get started and build real-world applications, from setting up your development environment to writing and debugging embedded code in Rust. We will also touch on other important aspects such as our tools, give an overview of our software product architecture, and teach how you can contribute to our project.
 
 ## Who This Book Is For
 
@@ -14,9 +14,9 @@ This book is intended for people with some experience in Rust and assumes basic 
 
 In this book, we focus specifically on the `esp-rs` ecosystem. It does **not** serve as:
 
-- A general Rust programming language tutorial: Familiarity with the Rust language is assumed to get you started. 
+- A general Rust programming language tutorial: Familiarity with the Rust language is assumed to get you started.
 - An embedded development guide: Prior familiarity with basic embedded development is also assumed.
-- A collection of examples: This book explains the overall process of working with the `esp-rs` ecosystem. More examples can be found [here][examples]. 
+- A collection of examples: This book explains the overall process of working with the `esp-rs` ecosystem. More examples can be found [here][examples].
 
 Check the [Additional Resources][resources] section if you are not familiar with any of these concepts.
 
@@ -25,7 +25,7 @@ Check the [Additional Resources][resources] section if you are not familiar with
 
 ## Stability and Availability
 
-The `esp-rs` project is under active development and may be subject to changes as it evolves. While we strive for stability, users should expect periodic modifications as we improve the API, improve performance, and introduce new features. [Modules] that are already stabilized will not be subject to breaking changes, while the `unstable` parts of the drivers are being actively worked on and will likely undergo changes in future releases. 
+The `esp-rs` project is under active development and may be subject to changes as it evolves. While we strive for stability, users should expect periodic modifications as we improve the API, improve performance, and introduce new features. [Modules] that are already stabilized will not be subject to breaking changes, while the `unstable` parts of the drivers are being actively worked on and will likely undergo changes in future releases.
 
 Additionally, the embedded Rust ecosystem is still in its infancy; some dependencies, tools, or language features may change over time. We encourage developers to stay up to date with the latest releases and participate in discussions to help shape the future of Rust on Espressif platforms.
 
@@ -35,13 +35,13 @@ Additionally, the embedded Rust ecosystem is still in its infancy; some dependen
 
 If you're unfamiliar with certain concepts covered in this book or would like to deepen your understanding, the following resources may be helpful:
 
-| Resource                                               | Description                                                                          |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------ |
-| [The Rust Programming Language][rust-book]             | Learn Rust fundamentals before diving into embedded development.                     |
-| [The Embedded Rust Book][embedded-rust-book]           | A collection of resources from Rust's Embedded Working Group.                        |
-| [The Embedonomicon][embedonomicon]                     | Detailed insights into low-level embedded Rust programming.                          |
-| [Embedded Rust (no_std) on Espressif][no_std-training] | Guide for working in `no_std` environments with Espressif SoCs.                     |
-| [Awesome ESP Rust][awesome-esp-rust]                   | A list of resouces for development in the Rust programming language for ESP products | 
+| Resource                                               | Description                                                                           |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| [The Rust Programming Language][rust-book]             | Learn Rust fundamentals before diving into embedded development.                      |
+| [The Embedded Rust Book][embedded-rust-book]           | A collection of resources from Rust's Embedded Working Group.                         |
+| [The Embedonomicon][embedonomicon]                     | Detailed insights into low-level embedded Rust programming.                           |
+| [Embedded Rust (no_std) on Espressif][no_std-training] | Guide for working in `no_std` environments with Espressif SoCs.                       |
+| [Awesome ESP Rust][awesome-esp-rust]                   | A list of resources for development in the Rust programming language for ESP products |
 
 [rust-book]: https://doc.rust-lang.org/book/
 [embedded-rust-book]: https://docs.rust-embedded.org/book/index.html


### PR DESCRIPTION
Also:
- If we are going to maintain `no_std-training`, the defmt stuff needs to be reorganized as atm it duplicates some information.
- Both Alloc and Logging chapters explain stuff that are already taken care in `esp-generate`. I think there is some value on explain such things, but we should clearly mark that when using `esp-generate` all that will be handled by the tool.