### PR TITLE
Application development improvements

### DIFF
--- a/src/application-development/alloc.md
+++ b/src/application-development/alloc.md
@@ -1,4 +1,4 @@
-# Alloc
+# Allocating Memory
 
 In a `no_std` environment, the [`alloc`][alloc] crate is available as an option for heap allocation. It can be useful when working with crates that require alloc or when using dynamic collections like `Vec`.
 
@@ -18,15 +18,15 @@ build-std = ["alloc", "core"] # added alloc here
 3. Use `alloc` crate in your application
 ```rust
 // main.rs
-
 extern crate alloc;
 ```
 
 4. Initialize a global heap allocator providing a heap of the given size in bytes with the provided macro:
 ```rust
 // main.rs
+fn main() -> ! {
+    esp_alloc::heap_allocator!(size: 72 * 1024);
 
-esp_alloc::heap_allocator!(size: 72 * 1024);
 ```
 
 or when more customization is required using the function:
@@ -61,11 +61,11 @@ heap_allocator!(#[link_section = ".dram2_uninit"] size: 64000);
 Our chips have a few hundred kilobytes of internal RAM, which could be insufficient for some applications. The ESP32, ESP32-S2, and ESP32-S3 have the ability to use virtual addresses for external PSRAM (Psuedostatic RAM) memory. The external memory is usable is the same way as internal data RAM, with certain restrictions. The biggest restriction is that the atomic instructions do not work
 correctly when the memory they access is located in PSRAM. This means that
 the allocator must not be used to allocate `Atomic*` types - either directly
-or indirectly. ESP32 restrictions can be found [here]. 
+or indirectly. ESP32 restrictions can be found [here].
 
 ### Allocator Considerations
 
-You can only have **one global allocator** but the allocator can use multiple regions (e.g. PSRAM, internal RAM or even multiple blocks of them). You can use multiple allocators with the nightly-feature "allocator api" and with [`allocator api2`][allocator api2], which [`esp-alloc`][esp-alloc] implements.
+You can only have **one global allocator** but the allocator can use multiple regions (e.g. PSRAM, internal RAM or even multiple blocks of them). You can use multiple allocators with the nightly-feature `allocator api` and with [`allocator api2`][allocator api2], which [`esp-alloc`][esp-alloc] implements.
 
 [esp-alloc]: https://crates.io/crates/esp-alloc
 [alloc]: https://doc.rust-lang.org/alloc/

--- a/src/application-development/async.md
+++ b/src/application-development/async.md
@@ -1,6 +1,12 @@
-# Async
+# Async Options
 
-This section does not serve as an async tutorial or teaching material. For these purposes, visit [official async-book]. 
+> ⚠️ **Note**:  This section does not serve as an async tutorial or teaching material. For these purposes, visit [official async-book].
+
+`esp-hal` provides blocking and async API for most of the supported drivers. For more information and to get started, check our `examples` in the [esp-hal-package].
+
+## Embassy
+
+[Embassy] is an asynchronous (async) framework designed specifically for embedded Rust development; its [embassy-executor] crate provides an `async/await` executor which executes a fixed number of tasks, statically allocated at startup, though more can be added later. To spawn more tasks later, you may keep copies of the `Spawner` (it is `Copy`), for example by passing it as an argument to the initial tasks. For more information about `embassy` visit [Embassy book].
 
 The [`esp-hal-embassy`][esp-hal-embassy] crate provides integration between the [`esp-hal`][esp-hal] and the [Embassy] asynchronous framework. It provides support for:
 
@@ -9,16 +15,11 @@ The [`esp-hal-embassy`][esp-hal-embassy] crate provides integration between the 
 3. Embassy time driver
 4. Timer waiter queue
 
-`esp-hal` provides blocking and async API for most of the supported drivers. For more information and to get started, check our `examples` in the [esp-hal-package].
-
-## Embassy
-
-[Embassy] is an asynchronous (async) framework designed specifically for embedded Rust development; its [embassy-executor] crate provides an `async/await` executor which executes a fixed number of tasks, statically allocated at startup, though more can be added later. To spawn more tasks later, you may keep copies of the `Spawner` (it is `Copy`), for example by passing it as an argument to the initial tasks. For more information about `embassy` visit [Embassy book].
 
 
 ## RTIC
 
-[Real-Time Interrupt-driven Concurrency (RTIC)] is a concurrency framework for building real-time systems. Currently, the ESP32-C3 and the ESP32-C6 are supported.
+[Real-Time Interrupt-driven Concurrency (RTIC)] is a concurrency framework for building real-time systems. Currently, only ESP32-C3 and ESP32-C6 are supported.
 
 
 [official async-book]: https://rust-lang.github.io/async-book/

--- a/src/application-development/bootloader.md
+++ b/src/application-development/bootloader.md
@@ -1,12 +1,19 @@
-# Bootloader
+# Building a Custom ESP-IDF Bootloader
 
-The `espflash` includes pre-built ESP-IDF [bootloaders] that are compiled using the default settings, making it easy to get started without additional configuration. However, if you require more advanced functionality or custom settings, you will need to build the bootloader yourself to tailor it to your specific needs. To do that, you need to:
-1. [Set up esp-idf].
+The `espflash` and `cargo-espflash` include pre-built ESP-IDF [bootloaders] that are compiled using the default settings, making it easy to get started without additional configuration. However, if you require more advanced functionality or custom settings, you will need to build the bootloader yourself to tailor it to your specific needs.
+
+To build a custom ESP-IDF bootloader:
+1. [Install ESP-IDF][esp-idf-install].
 2. Create a new project or go to an already existing one.
-3. Make desired changes using `idf.py menuconfig`.
-4. Re-build with `idf.py set-target <CHIP_TARGET> build`.
-5. Use the built bootloader binary with `espflash flash --bootloader <your_esp_idf_project/build/bootloader/bootloader.bin>` command.
+   - Using any examples under the `esp-idf/examples` directory is the easiest way.
+3. Make desired changes using `idf.py menuconfig` or editing the `sdkconfig` file.
+   - See [Configuration Options Reference][config-reference] for more information.
+4. Build the bootloader with `idf.py set-target <CHIP_TARGET> build bootloader`.
+   - The resulting booloader binary will be placed under `build/bootloader/bootloader.bin`.
+5. Use the built bootloader binary in `espflash/cargo-espflash` with the `--bootloader` flag or with the [configuration file][espflash-config-file].
 
 
 [bootloaders]: https://github.com/esp-rs/espflash/tree/main/espflash/resources/bootloaders
-[Set up esp-idf]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/index.html#manual-installation
+[esp-idf-install]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/index.html#manual-installation
+[config-reference]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig-reference.html#configuration-options-reference
+[espflash-config-file]: https://github.com/esp-rs/espflash/tree/main/espflash#configuration-file

--- a/src/application-development/configuration.md
+++ b/src/application-development/configuration.md
@@ -6,7 +6,7 @@ The [`esp-config`][esp-config] crate provides a way to manage configuration sett
 
 The full list of available options can be found in the documentation of the `esp-*` crate you are using.
 
-For example, in esp-hal if you want to place a function in your code in the RAM (`ESP_HAL_CONFIG_PLACE_SPI_DRIVER_IN_RAM`), which is set to `false` as default, you need to create an environment variable with the same name and modify its value:
+For example, in `esp-hal` if you want to place a function in your code in the RAM (`ESP_HAL_CONFIG_PLACE_SPI_DRIVER_IN_RAM`), which is set to `false` as default, you need to create an environment variable with the same name and modify its value:
 
 ```toml
 # .cargo/config.toml
@@ -17,7 +17,7 @@ ESP_HAL_CONFIG_PLACE_SPI_DRIVER_IN_RAM="true"
 
 After modifying the `.cargo/config.toml` and `[env]` section, **clean build** is recommended.
 
-> ⚠️ **Note**: Setting the `env-vars` on the command line will have precedence over env section.
+> ⚠️ **Note**: Setting the environment variables on the command line will have precedence over env section.
 
 For more information see [esp-config] README.
 

--- a/src/application-development/index.md
+++ b/src/application-development/index.md
@@ -2,8 +2,8 @@
 
 This chapter covers essential topics for developing applications:
 
- - [Bootloader](./bootloader.md) (startup)
- - [Configuration](./configuration.md) (dynamic settings)
- - [Logging](./logging.md) (debugging and monitoring)
- - [Alloc](./alloc.md) (heap strategies in resource-constrained targets)
- - [Async](./async.md) (event-driven patterns without OS threads e.g., embassy)
+ - [Building a Custom ESP-IDF Bootloader](./bootloader.md)
+ - [Using `esp-config`](./configuration.md)
+ - [Logging](./logging.md)
+ - [Allocating Memory](./alloc.md)
+ - [Async Options](./async.md)

--- a/src/application-development/logging.md
+++ b/src/application-development/logging.md
@@ -1,14 +1,14 @@
 # Logging
 
-​Logging is a crucial aspect of embedded systems development, providing visibility into the system's behavior and aiding in debugging and monitoring. In the Rust ecosystem for ESP devices, two prominent logging frameworks are commonly used: the [`log`][log] crate and [`defmt`][defmt].
+​Logging is a crucial aspect of embedded systems development, providing visibility into the system's behavior and aiding in debugging and monitoring. In the Rust ecosystem for Espressif devices, two prominent logging frameworks are commonly used: [`defmt`][defmt] and [`log`][log].
 
-## The `defmt` Framework
+## `defmt`
 
-[defmt] is a highly efficient logging framework designed for resource-constrained environments, such as embedded systems. It offers compact, binary-encoded log messages, reducing the overhead associated with traditional string-based logging.​ For more information about see [defmt-documentation].
+[`defmt`][defmt] is a highly efficient logging framework designed for resource-constrained environments, such as embedded systems. It offers compact, binary-encoded log messages, reducing the overhead associated with traditional string-based logging.​ For more information about see [`demft` documentation][defmt-documentation].
 
 ### Integrating `defmt` with `probe-rs`
 
-1. Add dependencies to your `Cargo.toml`:
+1. Add the required dependencies to your `Cargo.toml`:
 ```toml
 defmt            = "0.3.10"
 esp-hal          = { version = "1.0.0-beta.0", features = ["defmt", "esp32c6"] }
@@ -20,14 +20,14 @@ rtt-target       = { version = "0.6.1", features = ["defmt"] }
 [env]
 DEFMT_LOG="info" # Set desired log level
 ```
-For more details about filtering see [filtering].
+   - For more details about filtering see [filtering].
 
 3. Initialize the Logger:
 ```rust
 use defmt::info;
 #[main]
 fn main() -> ! {
-    
+
     // Initialize RTT for use with defmt
     rtt_target::rtt_init_defmt!();
     info!("Hello world!");
@@ -39,14 +39,12 @@ fn main() -> ! {
 
 `esp-println` can be configured to work seamlessly with `defmt`, providing a global logger that outputs defmt-encoded messages. To set this up:​
 
-1. Add dependencies to your `Cargo.toml`:
+1. Add the required dependencies to your `Cargo.toml`:
 ```toml
 defmt            = "0.3.10"
 esp-hal          = { version = "1.0.0-beta.0", features = ["defmt", "esp32c6"] }
 esp-println      = { version = "0.13.0", features = ["defmt-espflash", "esp32c6"] }
 ```
-Ensure you specify the feature corresponding to your target device (e.g. `esp32c6` for ESP32-C6).
-
 2. Set log level in your `.config.toml`:
 ```toml
 [env]
@@ -54,20 +52,20 @@ DEFMT_LOG="info" # Set desired log level
 ```
 For more details about filtering see [filtering].
 
-3. Minimal example:
+3. Build the required dependencies and use the logger:
 ```rust
 use defmt::info;
 use esp_println as _;
 
 #[main]
 fn main() -> ! {
-    
+
     info!("Hello world!");
     // ...
 }
 ```
 
-## The `log` crate
+## `log`
 
 The [`log`][log] crate is a widely adopted logging facade in the Rust community. It defines a set of macros (`info!`, `warn!`, `error!`, etc.) to capture log messages at various levels.
 
@@ -81,7 +79,6 @@ esp-hal          = { version = "1.0.0-beta.0", features = ["esp32c6"] }
 esp-println      = { version = "0.13.0", features = ["esp32c6", "log"] }
 log              = { version = "0.4.21" }
 ```
-Ensure you specify the feature corresponding to your target device (e.g. `esp32c6` for ESP32-C6).
 
 2. Set log level in your `.config.toml`:
 ```toml
@@ -89,13 +86,13 @@ Ensure you specify the feature corresponding to your target device (e.g. `esp32c
 ESP_LOG="info" # Set desired log level
 ```
 
-3. Initialize the Logger:
+3. Initialize the logger:
 ```rust
 use log::info;
 
 #[main]
 fn main() -> ! {
-    
+
     // Set up esp-println as the logger
     esp_println::logger::init_logger_from_env();
     info!("Hello world!");
@@ -105,6 +102,5 @@ fn main() -> ! {
 
 [log]: https://crates.io/crates/log
 [defmt]: https://crates.io/crates/defmt
-[esp-println]: https://crates.io/crates/esp-println
 [defmt-documentation]: https://defmt.ferrous-systems.com/introduction
 [filtering]: https://defmt.ferrous-systems.com/filtering#filtering


### PR DESCRIPTION
Also:
- If we are going to maintain `no_std-training`, the defmt stuff needs to be reorganized as atm it duplicates some information.
- Both Alloc and Logging chapters explain stuff that are already taken care in `esp-generate`. I think there is some value on explain such things, but we should clearly mark that when using `esp-generate` all that will be handled by the tool.