### PR TITLE
Add a vocabulary

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -32,7 +32,7 @@ MinAlertLevel = suggestion # "suggestion", "warning", or "error"
 # - accept.txt -- lists words with accepted case-sensitive spelling
 # - reject.txt -- lists words whose occurrences throw an error
 # Vocab = Espressif
-
+Vocab = book
 
 # Specify the packages to import into your project.
 # A package is a zip file containing a number of rules (style) written in YAML.

--- a/.vale/styles/config/vocabularies/book/accept.txt
+++ b/.vale/styles/config/vocabularies/book/accept.txt
@@ -1,0 +1,2 @@
+HAL
+esp-hal


### PR DESCRIPTION
I am not sure I know what I'm doing here but this should get rid of the annoying warnings about `HAL` by using a vocabulary

If this is a wrong approach feel free to close this
