### PR TITLE
doc: update instructions to install espup #509

### DIFF
--- a/src/installation/riscv-and-xtensa.md
+++ b/src/installation/riscv-and-xtensa.md
@@ -6,7 +6,7 @@
 
 To install `espup`, run:
 ```shell
-cargo install espup
+cargo install espup --locked
 ```
 
 You can also directly download pre-compiled [release binaries][release-binaries] or use [`cargo-binstall`][cargo-binstall].


### PR DESCRIPTION
I'm completely new to rust and cargo and I don't know the common practices (yet), 
but imo it makes sense to consider locked dependencies to avoid issues as reported in https://github.com/esp-rs/espup/issues/509 to give new users a safer starting point.