### PR TITLE
Fix hyperlink (after `esp-wifi` -> `esp-radio` repo rename)

### DIFF
--- a/src/overview/using-the-core-library.md
+++ b/src/overview/using-the-core-library.md
@@ -25,14 +25,14 @@ The table below covers the current support for `no_std` at this moment for diffe
 
 > ⚠️ **Note**:
 >
-> - ✅ in Wi-Fi/BLE/ESP-NOW means that the target supports, at least, one of the listed technologies. For details, see [Current support][esp-wifi-current-support] table of the esp-wifi repository.
+> - ✅ in Wi-Fi/BLE/ESP-NOW means that the target supports, at least, one of the listed technologies. For details, see [Current support][esp-radio-current-support] table of the esp-radio repository.
 > - [ESP8266 HAL][esp8266-hal] is in maintenance mode and no further development will be done for this chip.
 
 [esp-hal]: https://github.com/esp-rs/esp-hal/tree/main/esp-hal "Hardware abstraction layer"
 [esp-wifi]: https://github.com/esp-rs/esp-hal/tree/main/esp-wifi "Wi-Fi, BLE and ESP-NOW support"
 [esp-backtrace]: https://github.com/esp-rs/esp-hal/tree/main/esp-backtrace "Exception and panic handlers"
 [esp-storage]: https://github.com/esp-rs/esp-hal/tree/main/esp-storage "Embedded-storage traits to access unencrypted flash memory"
-[esp-wifi-current-support]: https://github.com/esp-rs/esp-hal/tree/main/esp-wifi#current-support
+[esp-radio-current-support]: https://github.com/esp-rs/esp-hal/tree/main/esp-radio#current-support
 [esp8266-hal]: https://github.com/esp-rs/esp8266-hal "ESP8266 Hardware abstraction layer"
 
 ### Relevant `esp-rs` Crates


### PR DESCRIPTION
The original link (https://github.com/esp-rs/esp-hal/tree/main/esp-wifi#current-support) is dead, and instead needs to go to the right repository (`esp-radio`, and not `esp-wifi` since it was renamed).

Refering to the hyperlink in the book shown here:
<img width="780" height="103" alt="image" src="https://github.com/user-attachments/assets/6867d0bf-c2f3-486c-9239-d1a15b38a4c5" />
