### PR TITLE
fix: typo and make pars symmetric

### DIFF
--- a/src/application-development/bootloader.md
+++ b/src/application-development/bootloader.md
@@ -5,7 +5,7 @@ Upon power up, many embedded devices will just start executing code from an addr
 To boot an application, Espressif devices use 2 bootloaders:
 
 - First Stage Bootloader (ROM Bootloader): Sets up architecture-specific registers, checks the [boot mode][boot-mode] and reset reason, and loads the second stage bootloader. This bootloader is burned into ROM, and exists as part of SoC and therefore doesn't need to be flashed, nor can it be changed.
-- Second Stage Bootloader: Loads your application and sets up the memory(RAM, PSRAM or flash).
+- Second Stage Bootloader: Loads your application and sets up the memory (RAM, PSRAM or flash).
 
 The second stage bootloader whilst not _technically_ required, is advised as it allows OTA support (the first stage bootloader only loads applications from a fixed offset in flash) and also enables flash encryption and secure boot. For more information, see the [OTA section](./ota.md).
 

--- a/src/getting-started/using-esp-generate.md
+++ b/src/getting-started/using-esp-generate.md
@@ -27,7 +27,7 @@ There are two options for flashing the code to the target device:
 - `probe-rs`: Enables Real Time Transfer (RTT) based options and allows on chip debugging.
   - Make sure to enable `Use probe-rs to flash and monitor instead of espflash.` (`probe-rs` option) when generating your project.
 
-> 💡 **Hint**: When using `espflash` you might want to enable `Use esp-backtrace as the panic handler.` and `Use the log crate to print messages.` under `Flashing, logging and debugging (espflash)`
+> 💡 **Hint**: When using `espflash` you might want to enable `Use the log crate to print messages.` and `Use esp-backtrace as the panic handler.` under `Flashing, logging and debugging (espflash)`
 
 > 💡 **Hint**: When using `probe-rs`, instead of `espflash`, you might want to enable `Use defmt to print messages.` and `Use panic-rtt-target as the panic handler.` under `Flashing, logging and debugging (probe-rs)`
 


### PR DESCRIPTION
You may want to squash the PR so that my "merge" isnt there. I will do it from my branch next time.

Note that I only change the paragraph so it is symmetric with the one below it, this makes comparison much easier for a human.