### PR TITLE
Use markdown admonitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,11 @@ jobs:
           toolchain: nightly
           components: rust-docs
 
-      - uses: jontze/action-mdbook@v4
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
+      - name: Setup mdBook
+        run: |
+          cd ~/.cargo/bin
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.5.1/mdbook-v0.5.1-x86_64-unknown-linux-gnu.tar.gz | tar xvzf -
+          echo "818d38d93524154bcb4847444bc0645b14da9ad729dacc7155ce477c26ac9470 mdbook" | sha256sum -c -
 
       - name: Check for broken links
         run: |

--- a/.vale/styles/config/vocabularies/book/accept.txt
+++ b/.vale/styles/config/vocabularies/book/accept.txt
@@ -11,3 +11,8 @@ JTAG
 USB
 RGB
 MIT
+(?i)NOTE
+(?i)TIP
+(?i)IMPORTANT
+(?i)WARNING
+(?i)CAUTION

--- a/rust-doc-style-guide.md
+++ b/rust-doc-style-guide.md
@@ -63,6 +63,7 @@ In heading titles, capitalize the first letter of every word **except for**:
   > **Packages and Crates**
 
 - Prepositions of four letters or less; unless these prepositions are the first or last words.
+
   - Prepositions of _five_ letters and above should be capitalized (Before, Through, Versus, Among, Under, Between, Without, etc.).
 
   > **Peripherals as State Machines**
@@ -110,7 +111,7 @@ The books on Rust usually use the following link formatting:
 
 - Make intra-book links relative, so they work both online and locally
 
-Do *not* turn long phrases into links
+Do _not_ turn long phrases into links
 
   > ❌ See the [Rust Reference’s section on constant evaluation](https://doc.rust-lang.org/book/ch03-01-variables-and-mutability.html) for more information on what operations can be used when declaring constants.
 
@@ -146,6 +147,7 @@ The books on Rust usually use the following list formatting:
   > - Building your C or C++ code to be integrated with the Rust code
 
 - If a bullet point is a full sentence, you can end it with a full stop.
+
   - If a list has at least one full stop, end all other list items with a full stop.
 
   > To reliably interact with these peripherals:
@@ -156,13 +158,13 @@ The books on Rust usually use the following list formatting:
 
 - For longer list items, consider using a summary word of phrase to make content [scannable](https://learn.microsoft.com/en-us/style-guide/scannable-content/).
 
-  > If you run Windows on your host machine, make sure 
+  > If you run Windows on your host machine, make sure
   >
-  > - **MSVC**: Recommended ABI, included in 
-  > - **GNU**: ABI used by the GCC toolchain 
+  > - **MSVC**: Recommended ABI, included in
+  > - **GNU**: ABI used by the GCC toolchain
 
-  -  For an example using bold font, see the list in the [Modules Cheat Sheet](https://doc.rust-lang.org/book/ch07-02-defining-modules-to-control-scope-and-privacy.html#modules-cheat-sheet) section in The Rust Programming Language book.
-  -  For an example using monospace font, see the [Panicking](https://docs.rust-embedded.org/book/start/panicking.html#panicking) section in The Embedded Rust Book.
+  - For an example using bold font, see the list in the [Modules Cheat Sheet](https://doc.rust-lang.org/book/ch07-02-defining-modules-to-control-scope-and-privacy.html#modules-cheat-sheet) section in The Rust Programming Language book.
+  - For an example using monospace font, see the [Panicking](https://docs.rust-embedded.org/book/start/panicking.html#panicking) section in The Embedded Rust Book.
 
 ## Using `monospace`
 
@@ -191,7 +193,6 @@ Use monospace font for the following items:
 - Files: `config.toml`
 - Images and containers: `idf-rust`
 
-
 ### Monospace and Other Types of Formatting
 
 Monospace font can also be used in:
@@ -215,7 +216,7 @@ Monospace font can also be used in:
 
   > When `s` comes _into_ scope, it is valid. It remains valid until it goes _out of_ scope.
 
-- Do *not* use italics with Espressif product names, such as ESP32.
+- Do _not_ use italics with Espressif product names, such as ESP32.
 
 ## Mode of Narration
 
@@ -254,20 +255,24 @@ Use the following formatting for notes and warnings:
 
 - Note
 
-  > ⚠️ **Note**: A note covering an important point or idea. Use sparingly or the readers will start ignoring them.
+  > [!NOTE]
+  > A note covering an important point or idea. Use sparingly or the readers will start ignoring them.
 
 - Warning
 
-  > 🚨 **Warning**: Use in critical circumstances only, e.g., for irreversible actions or actions potentially harmful to hardware, software, etc.
+  > [!WARNING]
+  > Use in critical circumstances only, e.g., for irreversible actions or actions potentially harmful to hardware, software, etc.
 
-- Hint
+- Tip
 
-  > 💡 **Hint**: Use for additional hints and tips
+  > [!TIP]
+  > Use for additional hints and tips
 
 In markdown:
 
 ```md
-> ⚠️ **Note**: Write your note.
+> [!NOTE]
+> Write your note.
 ```
 
 ## Prioritization
@@ -287,4 +292,3 @@ In markdown:
 - [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
 - [Rust Style Guide](https://riptutorial.com/rust/topic/4620/rust-style-guide) (riptutorial.com)
 - [Rust Style Guide](https://github.com/rust-lang/style-team/blob/master/guide/guide.md) (github.com/rust-lang)
-

--- a/src/application-development/alloc.md
+++ b/src/application-development/alloc.md
@@ -8,7 +8,7 @@ We provide our own `no_std` heap allocator, [`esp-alloc`][esp-alloc]. But before
 
 While heap allocation offers flexibility, it comes with some costs:
 
-- **Fragmentation**: Over time, dynamic allocation can cause *fragmentation*: small, scattered allocations may prevent large ones even if total memory is available. This can lead to subtle runtime failures.
+- **Fragmentation**: Over time, dynamic allocation can cause _fragmentation_: small, scattered allocations may prevent large ones even if total memory is available. This can lead to subtle runtime failures.
 - **Runtime Overhead**: Allocating and freeing memory incurs a computational cost, along with any overhead of the chosen allocator.
 
 ## Configurable Memory Placement and Reclaimed RAM
@@ -30,9 +30,10 @@ heap_allocator!(#[ram(reclaimed)] size: 64000);
 
 Our chips have a few hundred kilobytes of internal RAM, which could be insufficient for some applications. Some Espressif chips have the ability to use virtual addresses for external PSRAM (Pseudostatic RAM) memory. The external memory is usable in the same way as internal data RAM, with certain restrictions.
 
-> ⚠️ **Note**: On Xtensa chips, atomics in PSRAM do not work correctly — they can cause data races and defeat their purpose. This means that
-the allocator must not be used to allocate `Atomic*` types - either directly
-or indirectly. ESP32 restrictions can be found [here]. This does **not** affect our RISC-V chips, where PSRAM works correctly with atomics.
+> [!NOTE]
+> On Xtensa chips, atomics in PSRAM do not work correctly — they can cause data races and defeat their purpose. This means that
+> the allocator must not be used to allocate `Atomic*` types - either directly
+> or indirectly. ESP32 restrictions can be found [here]. This does **not** affect our RISC-V chips, where PSRAM works correctly with atomics.
 
 ### Allocator Considerations
 

--- a/src/application-development/async.md
+++ b/src/application-development/async.md
@@ -1,11 +1,12 @@
 # Async Options
 
-> ⚠️ **Note**:  This section does not serve as an async tutorial or teaching material. For these purposes, visit [official async-book].
+> [!NOTE]
+> This section does not serve as an async tutorial or teaching material. For these purposes, visit [official async-book].
 
 `esp-hal` provides blocking and async API for most of the supported drivers. Drivers are constructed in [`Blocking`] mode by default. To set up an async driver, they must be converted to an [`Async`] mode using the `into_async` method. For more information and to get started, check our `examples` in the [esp-hal package].
 
-> ⚠️ **Note**: Our `Async` drivers are not `Send` because they register interrupts on the current core. Moving them to another core can cause issues. If user needs to send (move) a driver to another core, they should send the `Blocking` version, and then call `into_async` on the correct core to bind it correctly.
-
+> [!NOTE]
+> Our `Async` drivers are not `Send` because they register interrupts on the current core. Moving them to another core can cause issues. If user needs to send (move) a driver to another core, they should send the `Blocking` version, and then call `into_async` on the correct core to bind it correctly.
 
 ## Embassy
 
@@ -26,11 +27,10 @@ The [`esp-rtos`] crate provides integration between [`esp-hal`] and the [Embassy
 
 [Real-Time Interrupt-driven Concurrency (RTIC)] is a community supported concurrency framework for building real-time systems. Real time tasks are not async, but "software" tasks are async. Currently, only ESP32-C3 and ESP32-C6 are supported.
 
-
 <!-- TODO: change ArielOS to crates.io link when it's ready -->
 [official async-book]: https://rust-lang.github.io/async-book/
 [`Blocking`]: https://docs.espressif.com/projects/rust/esp-hal/1.0.0/esp32c6/esp_hal/struct.Blocking.html
-[`Async`]:  https://docs.espressif.com/projects/rust/esp-hal/1.0.0/esp32c6/esp_hal/struct.Async.html
+[`Async`]: https://docs.espressif.com/projects/rust/esp-hal/1.0.0/esp32c6/esp_hal/struct.Async.html
 [Embassy]: https://embassy.dev
 [embassy-executor]: https://crates.io/crates/embassy-executor
 [`esp-rtos`]: https://crates.io/crates/esp-rtos

--- a/src/application-development/configuration.md
+++ b/src/application-development/configuration.md
@@ -15,23 +15,26 @@ You are free to do this in two ways:
 - By setting the environment variable. For example, in `esp-hal` if you want to place anonymous symbols in RAM (`ESP_HAL_CONFIG_PLACE_ANON_IN_RAM`), which is set to `false` by default, you need to create an environment variable with the same name and modify its value.
 
 - By setting the required parameter in `.cargo/config.toml` (this method also sets the environment variable):
-    ```toml
-    # .cargo/config.toml
 
-    [env]
-    ESP_HAL_CONFIG_PLACE_ANON_IN_RAM="true"
-    ```
-    After modifying the `.cargo/config.toml` and `[env]` section, **clean build** is recommended.
+  ```toml
+  # .cargo/config.toml
 
-> ⚠️ **Note**: Setting environment variables on the command line will take precedence over the `[env]` section.
+  [env]
+  ESP_HAL_CONFIG_PLACE_ANON_IN_RAM="true"
+  ```
+
+  After modifying the `.cargo/config.toml` and `[env]` section, **clean build** is recommended.
+
+> [!NOTE]
+> Setting environment variables on the command line will take precedence over the `[env]` section.
 
 ## Multiple Configurations
 
 Depending on your application, you may find yourself wanting to support different boards/chips/targets in the same project. In this case, you may have specific options to set for each target. To do this, we recommend the following setup.
 
-* A baseline `.cargo/config.toml` which has your typical build modifying flags (Cargo will _always_ read and respect this file, regardless of other `--config`'s passed)
-* A config file for each configuration in `.cargo/`
-* (**Recommended**) A Cargo [alias] to build with the given config, for example `run-config-a = "run --config=./.cargo/config_a.toml --release"`, but for simple cases you can pass `--config` on the CLI.
+- A baseline `.cargo/config.toml` which has your typical build modifying flags (Cargo will _always_ read and respect this file, regardless of other `--config`'s passed)
+- A config file for each configuration in `.cargo/`
+- (**Recommended**) A Cargo [alias] to build with the given config, for example `run-config-a = "run --config=./.cargo/config_a.toml --release"`, but for simple cases you can pass `--config` on the CLI.
 
 Check out [this example repo] for a more comprehensive look at multi-config projects.
 

--- a/src/getting-started/toolchain.md
+++ b/src/getting-started/toolchain.md
@@ -4,12 +4,15 @@
 
 Make sure you have [Rust][rust-lang-org] installed. If not, see the instructions on the [rustup][rustup.rs-website] website.
 
-> 🚨 **Warning**: When using Unix based systems, installing Rust via a system package manager (e.g. `brew`, `apt`, `dnf`, etc.) can result in various [issues and incompatibilities][rustup-note], so it's best to use [rustup][rustup.rs-website] instead.
+> [!WARNING]
+> When using Unix based systems, installing Rust via a system package manager (e.g. `brew`, `apt`, `dnf`, etc.) can result in various [issues and incompatibilities][rustup-note], so it's best to use [rustup][rustup.rs-website] instead.
 
 When using Windows, make sure you have installed one of the ABIs listed below. For more details, see the [Windows][rustup-book-windows] chapter in The rustup book.
+
 - **MSVC**: Recommended ABI, included in the list of `rustup` default requirements. Use it for interoperability with the software produced by Visual Studio.
 
     When in doubt, this is what you want to use.
+
 - **GNU**: ABI used by the GCC toolchain. Install it yourself for interoperability with the software built with the MinGW/MSYS2 toolchain.
 
 See also [alternative installation methods][rust-alt-installation].
@@ -25,23 +28,24 @@ See also [alternative installation methods][rust-alt-installation].
 To build Rust applications for the Espressif chips based on RISC-V architecture (if you're unsure what your device is, see [hardware overview](../introduction/hardware-overview.md)), do the following:
 
 1. Install the proper toolchain with the `rust-src` [component][rustup-book-components]:
-    - You can use either `stable` or [`nightly`][rustup-book-channel-nightly]:
-      ```shell
-      rustup toolchain install stable --component rust-src
+
+   - You can use either `stable` or [`nightly`][rustup-book-channel-nightly]:
+     ```shell
+     rustup toolchain install stable --component rust-src
       ```
       or
       ```shell
-      rustup toolchain install nightly --component rust-src
-      ```
+     rustup toolchain install nightly --component rust-src
+     ```
 
-    > ⚠️ **Note**: Other components such as `rustfmt`, `clippy` or `rust-analyzer` are not required, but they are highly recommended.
-
-
+   > [!NOTE]
+   > Other components such as `rustfmt`, `clippy` or `rust-analyzer` are not required, but they are highly recommended.
 
 2. Install the target:
-      ```shell
-      rustup target add riscv32imc-unknown-none-elf # For ESP32-C2 and ESP32-C3
-      rustup target add riscv32imac-unknown-none-elf # For ESP32-C6 and ESP32-H2
+
+   ```shell
+   rustup target add riscv32imc-unknown-none-elf # For ESP32-C2 and ESP32-C3
+   rustup target add riscv32imac-unknown-none-elf # For ESP32-C6 and ESP32-H2
       ```
 
       Those targets are currently [Tier 2][rust-lang-book--platform-support-tier2]. Note the different flavors of `riscv32` targets in Rust covering different [RISC-V extensions][wiki-riscv-standard-extensions].

--- a/src/getting-started/tooling/esp-generate.md
+++ b/src/getting-started/tooling/esp-generate.md
@@ -12,7 +12,8 @@ cargo install esp-generate --locked
 
 You can also directly download pre-compiled [release binaries][release-binaries] or use [`cargo-binstall`][cargo-binstall].
 
-> 💡 **Hint**: Each version of `esp-generate` targets a specific version of the ecosystem crates. Make sure to update `esp-generate` if you want to use the latest released versions.
+> [!TIP]
+> Each version of `esp-generate` targets a specific version of the ecosystem crates. Make sure to update `esp-generate` if you want to use the latest released versions.
 
 [release-binaries]: https://github.com/esp-rs/esp-generate/releases
 [cargo-binstall]: https://github.com/cargo-bins/cargo-binstall

--- a/src/getting-started/tooling/probe-rs.md
+++ b/src/getting-started/tooling/probe-rs.md
@@ -6,9 +6,10 @@ Besides flashing and monitoring, it also provides robust debugging capabilities.
 
 If you're unsure whether you need it right now, you can skip the installation and come back to it later.
 
-Espressif devices equipped with the  `USB-JTAG-SERIAL` peripheral can use `probe-rs` without any external hardware. For devices lacking this peripheral, you'll need an external programmer like the [ESP-Prog][esp-prog].
+Espressif devices equipped with the `USB-JTAG-SERIAL` peripheral can use `probe-rs` without any external hardware. For devices lacking this peripheral, you'll need an external programmer like the [ESP-Prog][esp-prog].
 
-> ⚠️ **Note**: `USB-JTAG-SERIAL` peripheral is available in ESP32-C6, ESP32-H2, ESP32-S3 and ESP32-C3 (revision 0.3 or later)
+> [!NOTE]
+> `USB-JTAG-SERIAL` peripheral is available in ESP32-C6, ESP32-H2, ESP32-S3 and ESP32-C3 (revision 0.3 or later)
 
 [probe-rs]: https://probe.rs/
 <!--- the search currently doesn't work on the probe-rs website --->

--- a/src/getting-started/using-esp-generate.md
+++ b/src/getting-started/using-esp-generate.md
@@ -18,7 +18,6 @@ Adjust the options as needed for your project. See [Available Options][available
 
 [available-options]: https://github.com/esp-rs/esp-generate?tab=readme-ov-file#available-options
 
-
 ## Flashing Options
 
 There are two options for flashing the code to the target device:
@@ -27,9 +26,11 @@ There are two options for flashing the code to the target device:
 - `probe-rs`: Enables Real Time Transfer (RTT) based options and allows on chip debugging.
   - Make sure to enable `Use probe-rs to flash and monitor instead of espflash.` (`probe-rs` option) when generating your project.
 
-> 💡 **Hint**: When using `espflash` you might want to enable `Use the log crate to print messages.` and `Use esp-backtrace as the panic handler.` under `Flashing, logging and debugging (espflash)`
+> [!TIP]
+> When using `espflash` you might want to enable `Use the log crate to print messages.` and `Use esp-backtrace as the panic handler.` under `Flashing, logging and debugging (espflash)`
 
-> 💡 **Hint**: When using `probe-rs`, instead of `espflash`, you might want to enable `Use defmt to print messages.` and `Use panic-rtt-target as the panic handler.` under `Flashing, logging and debugging (probe-rs)`
+> [!TIP]
+> When using `probe-rs`, instead of `espflash`, you might want to enable `Use defmt to print messages.` and `Use panic-rtt-target as the panic handler.` under `Flashing, logging and debugging (probe-rs)`
 
 ## Generating the Project
 

--- a/src/introduction/ancillary-crates.md
+++ b/src/introduction/ancillary-crates.md
@@ -36,7 +36,8 @@ The table below briefly describes all crates in the `esp-hal` ecosystem and thei
 | `xtensa-lx`              | Low-level access to Xtensa LX processors and peripherals.                                                      | Unstable              |
 | `xtensa-lx-rt`           | Minimal startup/runtime for Xtensa LX CPUs from Espressif.                                                     | Unstable              |
 
-> ⚠️ **Note**: The stability of individual peripheral drivers within `esp-hal` varies. Refer to the [Peripheral support section][peripheral-support] for per-peripheral stability details.
+> [!NOTE]
+> The stability of individual peripheral drivers within `esp-hal` varies. Refer to the [Peripheral support section][peripheral-support] for per-peripheral stability details.
 
 You can find details about any of these packages in the [esp-rs documentation][docs].
 

--- a/src/introduction/hardware-overview.md
+++ b/src/introduction/hardware-overview.md
@@ -5,18 +5,22 @@ The crates under the `esp-rs` organization include support for the [ESP32, ESP32
 Each SoC has its own unique features while sharing some common traits. To select the appropriate chip for your project, please use the [Espressif Product Selector][product-selector].
 
 The Espressif portfolio is based on two different system architectures:
+
 - [Xtensa][xtensa-architecture]: The ESP32 and ESP32-S series are based on the Xtensa architecture.
 - [RISC-V][riscv-architecture]: The ESP32-C and ESP32-H series are based on the RISC-V architecture.
 
 We won't go into the details or differences between the two architectures here. Rust's official support differs between the two architectures. Xtensa is not yet officially supported by Rust; the reason for Rust not supporting Xtensa is that Rust uses LLVM as part of its compiler infrastructure, and LLVM does not yet support Xtensa. For this reason, we maintain custom forks of both LLVM and the Rust compiler that include Xtensa support, and we are actively working to upstream our changes to enable official support in the future.
 
-> ⚠️ **Note**: We are actively working to upstream our forks. Below is the current status:
+> [!NOTE]
+> We are actively working to upstream our forks. Below is the current status:
+>
 > 1. LLVM fork: We've made significant progress recently. For details, refer to the [tracking issue][llvm-github-fork-upstream issue].
 > 2. Rust compiler fork: We've submitted all feasible Xtensa patches. Further progress depends on these changes being upstreamed into LLVM.
 
 Feel free to refer to the [Technical Documentation][espressif-docs] for more information about the different SoCs.
 
-> ⚠️ **Note**: The ESP8266 is not supported by `esp-hal`.
+> [!NOTE]
+> The ESP8266 is not supported by `esp-hal`.
 >
 > However, the ESP32-C2 (ESP8684) and ESP32-C3 (ESP8685) are supported. Notably, the ESP32-C3 is pin-compatible with the ESP8266, making it a suitable drop-in replacement.
 
@@ -47,8 +51,6 @@ Let's take the [ESP32-C6-DevKitC-1][c6-devkitc] as an example. It's a developmen
 - RGB LED: Addressable RGB LED, driven by GPIO8.
   - Note that this is not a standard RGB LED, it is a [WS2812B LED][esp-hal-smartled].
 
-
 [c6-devkitc]: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html
 [boot-mode-selection]: https://docs.espressif.com/projects/esptool/en/latest/esp32c6/advanced-topics/boot-mode-selection.html?highlight=boot%20mode
 [esp-hal-smartled]: https://github.com/esp-rs/esp-hal-community/tree/main/esp-hal-smartled
-


### PR DESCRIPTION
Mdbook supports [admonitions](https://rust-lang.github.io/mdBook/format/markdown.html?highlight=!note#admonitions) in Markdown, so we may as well use them.

Style guide has been updated to accommodate this. One minor change, _Hint_ is now _Tip_.