### PR TITLE
Hint to increase espflash's baudrate

### DIFF
--- a/src/getting-started/tooling/espflash.md
+++ b/src/getting-started/tooling/espflash.md
@@ -16,6 +16,10 @@ Alternatively, you can use [`cargo-binstall`][cargo-binstall] to download pre-co
 cargo binstall espflash
 ```
 
+> [!NOTE]
+> The default baudrate used by [`espflash`][espflash] is 115200 - you might want to increase it to make flashing faster.
+> The easiest way to do that is setting the `ESPFLASH_BAUD` environment variable.
+
 [cargo-binstall]: https://github.com/cargo-bins/cargo-binstall
 [releases]: https://github.com/esp-rs/espflash/releases
 [espflash]: https://github.com/esp-rs/espflash/tree/main/espflash/


### PR DESCRIPTION
Adds a hint about espflash's default-baudrate - while it's documented elsewhere it might be hard to discover as a beginner resulting in poor flashing times
